### PR TITLE
Update cdk in GitHub action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install deps
       run: npm install -g npm@7 && npm ci
     - name: Install CDK
-      run: npm install -g aws-cdk@2.9.0
+      run: npm install -g aws-cdk@2.32.1
     - name: Build Project
       run: npm run build
     - name: Build CDK Templates


### PR DESCRIPTION
Forgot to update the CDK version in the github action so it's not currently deploying because the global CDK doesn't match the local CDK version in package.json