### PR TITLE
Fix tokensList multi token searching, allow eq comparison

### DIFF
--- a/appsync/pools/requestMapper.vtl
+++ b/appsync/pools/requestMapper.vtl
@@ -59,12 +59,9 @@
         #elseif($filterSettings.get("contains"))
             #set($expressionTerms = "")
             #foreach($filterSetting in $filterSettings.contains)
-                #set($expressionTerms = "${expressionTerms} :${filter}_c${velocityCount}")
-                #if( $foreach.hasNext ) #set($expressionTerms = "${expressionTerms},")  #end
+                #set($expressionTerms = ":${filter}_c${velocityCount}")
                 #set($ddbDescriber = {"S": $filterSetting})
                 $util.qr($expressionValues.put(":${filter}_c${velocityCount}", $ddbDescriber))
-            #end
-            #if ($expressionTerms != "")
             	$util.qr($filterExpressions.add("contains(${filter}, ${expressionTerms})"))
             #end
         #** The general filter runs the built-in function toDynamoDBFilterExpression on any other options in the 

--- a/appsync/pools/schema.graphql
+++ b/appsync/pools/schema.graphql
@@ -107,7 +107,7 @@ input TablePoolsFilterInput {
 	swapFee: TableFloatFilterInput
 	owner: TableStringFilterInput
 	factory: TableStringFilterInput
-	tokensList: TableStringFilterInput
+	tokensList: TableStringArrayFilterInput
 	totalWeight: TableFloatFilterInput
 	totalSwapVolume: TableFloatFilterInput
 	totalSwapFee: TableFloatFilterInput
@@ -125,6 +125,12 @@ input TablePoolsFilterInput {
 	wrappedIndex: TableIntFilterInput
 	lowerTarget: TableFloatFilterInput
 	upperTarget: TableFloatFilterInput
+}
+
+input TableStringArrayFilterInput {
+	ne: [String]
+	eq: [String]
+	contains: [String]
 }
 
 input TableStringFilterInput {


### PR DESCRIPTION
- Fix a bug where tokensList searching wasn't working with more than one token in the array.
- Add new `eq` filter input for tokensList that allows comparing to an array so can find pools with an exact token list instead of "tokens list contains these tokens".

## Explanation

This is the code that converts the GraphQL request into a DynamoDB request. The GraphQL request would look something like this:

```
where: { 
    tokenList: { 
        contains: ['0xABC', '0xDEF'] 
    } 
}
```

This was being converted into the following DynamoDB filter: (done at the very end of requestMapper.vtl)

```
filter: {
    expression: "contains(tokenList, :tokenList_c1, :tokenList_c2)"
    expressionNames: {},
    expressionValues: {
        ":tokenList_c1": "0xABC",
        ":tokenList_c2": "0xDEF"
    }
}
```

But that contains filter is only supposed to compare to one item at a time. So the change turned each tokenId into a separate $filterExpressionString array item, so that now it looks like:

```
filter: {
    expression: "contains(tokenList, :tokenList_c1) AND contains(tokenList, :tokenList_c2)"
    expressionNames: {},
    expressionValues: {
        ":tokenList_c1": "0xABC",
        ":tokenList_c2": "0xDEF"
    }
}
```

## Allowing eq for tokenList

The schema.graphql change made the tokensList an array item so that you could compare it to another array with eq and it would parse correctly. Previously you could only do eq with a string. 