### PR TITLE
Update pools in DynamoDB instead of inserting

### DIFF
--- a/src/data-providers/dynamodb-marshaller.spec.ts
+++ b/src/data-providers/dynamodb-marshaller.spec.ts
@@ -1,5 +1,5 @@
 import { Pool } from '../types';
-import { marshallPool, unmarshallPool } from './dynamodb-marshaller';
+import { generateUpdateExpression, marshallPool, unmarshallPool } from './dynamodb-marshaller';
 import POOLS from '../../test/mocks/pools';
 
 describe('DynamoDB Marshaller', () => {
@@ -145,5 +145,82 @@ describe('DynamoDB Marshaller', () => {
       const unmarshalledPool = unmarshallPool(marshalledPool);
       expect(unmarshalledPool).toMatchObject(originalPool);
     });
-  })
+  });
+
+  describe('generateUpdateExpression', () => {
+    const pool = {
+      id: '0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5000200000000000000000025',
+      totalShares: '39522955.298207500034572608',
+      swapEnabled: true,
+      poolType: "Weighted",
+      address: "0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5",
+      chainId: 1,
+      tokens: [
+        {
+          weight: '0.5',
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          priceRate: '1',
+          balance: '4318.529528',
+          decimals: 6
+        },
+        {
+          weight: '0.5',
+          address: '0xba100000625a3754423978a60c9317c58a424e3d',
+          priceRate: '1',
+          balance: '250.958639102476791721',
+          decimals: 18
+        }
+      ]
+    }
+
+    const expectedUpdateExpression: UpdateExpression = {
+      UpdateExpression: 'SET #totalShares = :totalShares, #swapEnabled = :swapEnabled, #poolType = :poolType, #address = :address, #tokens = :tokens',
+      ExpressionAttributeNames: {
+        '#totalShares': 'totalShares',
+        '#swapEnabled': 'swapEnabled',
+        '#poolType': 'poolType',
+        '#address': 'address',
+        '#tokens': 'tokens'
+      },
+      ExpressionAttributeValues: {
+        ':totalShares': { 
+          N: '39522955.298207500034572608' 
+        },
+        ':swapEnabled': {
+          BOOL: true
+        },
+        ':poolType': {
+          S: 'Weighted' 
+        },
+        ':address': {
+          S: '0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5'
+        },
+        ':tokens': {
+          L: [
+            {
+              M: {
+                weight: { S: '0.5' },
+                address: { S: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' },
+                priceRate: { S: '1' },
+                balance: { S: '4318.529528' },
+                decimals: { N: '6' }
+              }
+            },
+            {
+              M: {
+                weight: { S: '0.5' },
+                address: { S: '0xba100000625a3754423978a60c9317c58a424e3d' },
+                priceRate: { S: '1' },
+                balance: { S: '250.958639102476791721' },
+                decimals: { N: '18' }
+              }
+            }
+          ]
+        }
+      }
+    }
+
+    const updateExpression = generateUpdateExpression(pool as Pool);
+    expect(updateExpression).toEqual(expectedUpdateExpression);
+  });
 })

--- a/src/data-providers/dynamodb.spec.ts
+++ b/src/data-providers/dynamodb.spec.ts
@@ -2,7 +2,7 @@ import AWS from 'aws-sdk';
 import { Pool } from '../types';
 import POOLS from '../../test/mocks/pools';
 import { updatePools } from './dynamodb';
-import { marshallPool } from './dynamodb-marshaller';
+import { generateUpdateExpression, marshallPool } from './dynamodb-marshaller';
 
 
 jest.mock('aws-sdk', () => {
@@ -26,15 +26,27 @@ describe('DynamoDB', () => {
 
       const expectedRequest = {
         TransactItems: [{
-          Update: {
-            Key: marshallPool(pools[0]),
-            TableName: 'pools'
-          }
+          Update: Object.assign(
+            {
+              Key: {
+                id: { 'S': pools[0].id },
+                chainId: { 'N': pools[0].chainId.toString() }
+              },
+              TableName: 'pools'
+            }, 
+            generateUpdateExpression(pools[0])
+          )
         }, {
-          Update: {
-            Key: marshallPool(pools[1]),
-            TableName: 'pools'
-          }
+          Update: Object.assign(
+            {
+              Key: {
+                id: { 'S': pools[1].id },
+                chainId: { 'N': pools[1].chainId.toString() }
+              },
+              TableName: 'pools'
+            }, 
+            generateUpdateExpression(pools[1])
+          )
         }]
       }
 

--- a/src/data-providers/dynamodb.spec.ts
+++ b/src/data-providers/dynamodb.spec.ts
@@ -1,0 +1,51 @@
+import AWS from 'aws-sdk';
+import { Pool } from '../types';
+import POOLS from '../../test/mocks/pools';
+import { updatePools } from './dynamodb';
+import { marshallPool } from './dynamodb-marshaller';
+
+
+jest.mock('aws-sdk', () => {
+  const mDynamoDB = { 
+    transactWriteItems: jest.fn(() => { 
+      return { promise: () => Promise.resolve() }
+    }),
+    batchWriteItem: jest.fn(() => { 
+      return { promise: () => Promise.resolve() }
+    }),
+  };
+  return { DynamoDB: jest.fn(() => mDynamoDB) };
+});
+
+const mDynamoDB = new AWS.DynamoDB();
+
+describe('DynamoDB', () => {
+  describe('updatePools', () => {
+    it('Should perform a transactWriteItem for each pool', async () => {
+      const pools: Pool[] = POOLS.slice(0, 2);
+
+      const expectedRequest = {
+        TransactItems: [{
+          Update: {
+            Key: marshallPool(pools[0]),
+            TableName: 'pools'
+          }
+        }, {
+          Update: {
+            Key: marshallPool(pools[1]),
+            TableName: 'pools'
+          }
+        }]
+      }
+
+      await updatePools(pools);
+      expect(mDynamoDB.transactWriteItems).toBeCalledWith(expectedRequest, expect.anything());
+    });
+
+    it('Should break pool updates into chunks of 25', () => {
+      const pools: Pool[] = POOLS.slice(0).concat(POOLS.slice(0)).concat(POOLS.slice(0));
+      expect(pools.length).toBe(30); // sanity check
+    });
+
+  });
+})

--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -60,7 +60,6 @@ export async function updatePools(pools: Pool[]) {
     const params = {
       TransactItems: poolUpdateRequests 
     };
-    console.log("Calling with params: ", params);
     return dynamodb.transactWriteItems(params, (err) => {
       if (err) {
         console.error(`Unable to update pools ${JSON.stringify(poolUpdateRequests)} Error JSON: ${JSON.stringify(err, null, 2)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,11 @@ export interface Schema {
     }
 }
 
+export interface UpdateExpression {
+    UpdateExpression: string
+    ExpressionAttributeNames: {[key: string]: string},
+    ExpressionAttributeValues: {[key: string]: string},
+}
 export interface TRMAccountDetails {
     accountExternalId: string | null;
     address: string;


### PR DESCRIPTION
- Changes the pool update method to update the existing pools instead of inserting new ones so that parameters that are not included in the update are not lost.
- Start adding unit tests for DynamoDB requests

Fixes an issue where when doing a pools update it was losing `totalLiquidity` and `lastUpdate` that are updated by the decorate lambda function. 

Tested in development and it's working there