### PR TITLE
Don't use disabled pools in SOR calculations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^0.1.19",
-        "@balancer-labs/sor": "^4.0.1-beta.1",
+        "@balancer-labs/sdk": "^0.1.21",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-cdk-lib": "^2.32.1",
@@ -652,14 +651,13 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.19.tgz",
-      "integrity": "sha512-A/AZHeuxQJuDSagj5ChWK78B8YtQe/RNkHC0cP7GSkCYDl3xDE36JhZdcnO6lWh8b/3rps4bZbysF1bn0fkLxA==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.21.tgz",
+      "integrity": "sha512-RPbcjR0olMXMUMFtjzeasNEvsTbCd7sRPX2QOelXLG27vyin4kP/o+YtQFqfya+rKXRikVpUn2yEZfWdA4mHkA==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.1-beta.1",
+        "@balancer-labs/sor": "^4.0.1-beta.3",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
-        "bignumber.js": "^9.0.2",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",
         "lodash": "^4.17.21"
@@ -676,9 +674,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.1.tgz",
-      "integrity": "sha512-LY+qHLJxqn1cOWfKOo+mjX/85BQLQhCBP9GCsks/kXV2vLnG9HefoxcwkqP1b5bB6uFzsT67lYl9CkSFvYM/UQ==",
+      "version": "4.0.1-beta.3",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.3.tgz",
+      "integrity": "sha512-xyMXsK45thq9Rqf3Ou8aIPMrg9aOtTy20wXCV39cb6K9ewWXp54XQRb3qFa8N8s+Zy3hau+FpwRbO55/zi41jg==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -8773,23 +8771,22 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.19.tgz",
-      "integrity": "sha512-A/AZHeuxQJuDSagj5ChWK78B8YtQe/RNkHC0cP7GSkCYDl3xDE36JhZdcnO6lWh8b/3rps4bZbysF1bn0fkLxA==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.21.tgz",
+      "integrity": "sha512-RPbcjR0olMXMUMFtjzeasNEvsTbCd7sRPX2QOelXLG27vyin4kP/o+YtQFqfya+rKXRikVpUn2yEZfWdA4mHkA==",
       "requires": {
-        "@balancer-labs/sor": "^4.0.1-beta.1",
+        "@balancer-labs/sor": "^4.0.1-beta.3",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
-        "bignumber.js": "^9.0.2",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",
         "lodash": "^4.17.21"
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.0.1-beta.1",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.1.tgz",
-      "integrity": "sha512-LY+qHLJxqn1cOWfKOo+mjX/85BQLQhCBP9GCsks/kXV2vLnG9HefoxcwkqP1b5bB6uFzsT67lYl9CkSFvYM/UQ==",
+      "version": "4.0.1-beta.3",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.3.tgz",
+      "integrity": "sha512-xyMXsK45thq9Rqf3Ou8aIPMrg9aOtTy20wXCV39cb6K9ewWXp54XQRb3qFa8N8s+Zy3hau+FpwRbO55/zi41jg==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^0.1.19",
+    "@balancer-labs/sdk": "^0.1.21",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-cdk-lib": "^2.32.1",

--- a/src/poolDataService.ts
+++ b/src/poolDataService.ts
@@ -1,7 +1,6 @@
 import { PoolDataService, SubgraphPoolBase } from '@balancer-labs/sdk';
 import { getPools } from "./data-providers/dynamodb";
 import debug from 'debug';
-import util from 'util';
 import { convertPoolToSubgraphPoolBase } from './utils';
 
 const log = debug('balancer:pool-data-service');

--- a/src/poolDataService.ts
+++ b/src/poolDataService.ts
@@ -21,8 +21,11 @@ export class DatabasePoolDataService implements PoolDataService {
     public async getPools(): Promise<SubgraphPoolBase[]> {
         log(`Retrieving pools for chain ${this.chainId} from the database`);
         const pools = await getPools(this.chainId);
-        log(`Retrieved pools:`, util.inspect(pools, false, null));
+        log(`Retrieved ${pools.length} pools`);
         const subgraphPools = pools.map((pool) => convertPoolToSubgraphPoolBase(pool))
-        return subgraphPools ?? [];
+        log(`Found ${subgraphPools.length} subgraph pools total`);
+        const enabledPools = subgraphPools.filter((pool) => pool.swapEnabled);
+        log(`Found ${enabledPools.length} enabled pools`)
+        return enabledPools ?? [];
     }
 }

--- a/src/sor.spec.ts
+++ b/src/sor.spec.ts
@@ -1,6 +1,6 @@
 import { Order } from './types';
 import { getSorSwap, _setLogger } from './sor';
-import { BalancerSDK, mockSwapCostCalculator } from '@balancer-labs/sdk';
+import { mockSwapCostCalculator } from '@balancer-labs/sdk';
 
 jest.mock('@balancer-labs/sdk');
 jest.mock('@ethersproject/providers');

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,6 @@ export interface SerializedSwapInfo {
 
 export interface Pool extends SDKPool {
   chainId: number;
-  swapEnabled?: boolean;
   graphData?: {
     totalLiquidity?: string;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,6 +172,5 @@ export function convertPoolToSubgraphPoolBase(pool: Pool): SubgraphPoolBase {
   return {
       ...pool, 
       ...{tokens},
-      ...{swapEnabled: pool.swapEnabled || true}
   } 
 }


### PR DESCRIPTION
Today we were notified of an issue with the pool `0x6fc73b9d624b543f8b6b88fc3ce627877ff169ee000200000000000000000235` which was enabled but now has swaps disabled yet our SOR calculator is still using it for calculations. 

This is because SOR filters out pools with `swapEnabled: false` in it's graph query and does no further filtering. So we need to ensure only enabled pools are returned by this PoolDataService. 

Also upgrading the SDK for the updated Pool type that has swapEnabled on it. 

I manually set swapEnabled on this pool to false (to match onchain data) because there is a second bug: Because we fetch these pools via SOR in the first place and SOR only retrieves enabled pools, if a pool gets disabled it is just never updated again and so stays enabled in DynamoDB. Will fix this in a future PR. 
