### PR TITLE
Should block any severe risk

### DIFF
--- a/src/lambdas/wallet-check.spec.ts
+++ b/src/lambdas/wallet-check.spec.ts
@@ -33,36 +33,7 @@ describe('Wallet Check Lambda', () => {
     expect(body.is_blocked).toBe(false);
   });
 
-  it('Should return false for an address that has a severe warning but it is type of counterparty', async () => {
-    trmResponse = [{
-      "accountExternalId": null,
-      "address": "0x0000000000000000000000000000000000000000",
-      "addressRiskIndicators": [
-        {
-          "category": "Sanctions",
-          "categoryId": "69",
-          "categoryRiskScoreLevel": 15,
-          "categoryRiskScoreLevelLabel": "Severe",
-          "incomingVolumeUsd": "100",
-          "outgoingVolumeUsd": "0",
-          "riskType": "COUNTERPARTY",
-          "totalVolumeUsd": "100"
-        }
-      ],
-      "addressSubmitted": "0x0000000000000000000000000000000000000000",
-      "chain": "ethereum",
-      "entities": [],
-      "trmAppUrl": "https://my.trmlabs.com/address/0x0000000000000000000000000000000000000000/eth"
-    }];
-    nock('https://api.trmlabs.com')
-      .post('/public/v2/screening/addresses')
-      .reply(200, trmResponse);
-    const response = await handler(request);
-    const body = JSON.parse(response.body);
-    expect(body.is_blocked).toBe(false);
-  });
-
-  it('Should return blocked for an address that has a Severe risk which is not counterparty', async () => {
+  it('Should return blocked for an address that has a Severe risk', async () => {
     trmResponse = [{
         "accountExternalId": null,
         "address": "0x0000000000000000000000000000000000000000",

--- a/src/lambdas/wallet-check.ts
+++ b/src/lambdas/wallet-check.ts
@@ -51,11 +51,7 @@ export const handler = async (event: any = {}): Promise<any> => {
     const entities: TRMEntity[] = result[0]?.entities || [];
   
     const hasSevereRisk = riskIndicators.some(
-      indicator =>  {
-        indicator.categoryRiskScoreLevelLabel === 'Severe' && 
-        indicator.riskType !== "COUNTERPARTY"
-
-      }
+      indicator => indicator.categoryRiskScoreLevelLabel === 'Severe'
     );
     const hasSevereEntity = entities.some(
       entity => entity.riskScoreLevelLabel === 'Severe'


### PR DESCRIPTION
The policy around blocking or not blocking counterparty risk wallets should be handled in TRM, not in the code.