### PR TITLE
If APR fails to calculate, update to empty APR object

### DIFF
--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -102,7 +102,6 @@ export class PoolService {
         `Failed to calculate APR. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
       );
-      return poolApr;
     }
 
     if (!isEqual(poolApr, this.pool.apr)) {

--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -34,7 +34,11 @@ export class PoolService {
         `Failed to calculate liquidity. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
       );
-      return '0';
+      // If we already have a totalLiquidity value, return it, 
+      // otherwise continue and save out 0 totalLiquidity so it's not left null
+      if (this.pool.totalLiquidity) {
+        return this.pool.totalLiquidity;
+      }
     }
 
     if (Number(poolLiquidity) == 0 && Number(this.pool.totalLiquidity) > 0) {
@@ -103,7 +107,7 @@ export class PoolService {
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
       );
       // If we already have an APR, return it, 
-      // otherwise continue and save out the 0 APR to this pool. 
+      // otherwise continue and save out the 0 APR to this pool so it's not left null 
       if (this.pool.apr) { 
         return this.pool.apr;
       }

--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -102,6 +102,11 @@ export class PoolService {
         `Failed to calculate APR. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
       );
+      // If we already have an APR, return it, 
+      // otherwise continue and save out the 0 APR to this pool. 
+      if (this.pool.apr) { 
+        return this.pool.apr;
+      }
     }
 
     if (!isEqual(poolApr, this.pool.apr)) {


### PR DESCRIPTION
Currently if the APR fails to calculate it is never set on a pool and so an APR of `null` is returned by the API. Instead it should continue and return the 0 APR object so that all APR's have have a value. 