### PR TITLE
Reduce logs

### DIFF
--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -62,6 +62,10 @@ export async function updatePools(pools: Pool[]) {
     };
     return dynamodb.transactWriteItems(params, (err) => {
       if (err) {
+        if (err.code === 'ProvisionedThroughputExceededException') {
+          console.error('Unable to update pools - Table Throughput exceeded');
+          return;
+        }
         console.error(`Unable to update pools ${JSON.stringify(poolUpdateRequests)} Error JSON: ${JSON.stringify(err, null, 2)}`);
       }
     }).promise();


### PR DESCRIPTION
Currently if the update pools function fails because the table throughput is exceeded it logs out the entire request which takes up a lot of log space and isn't needed. We only need to log out the entire request if it fails for some other reason. This will save on log usage which will save on our costs. 