### PR TITLE
Update Balancer SDK to fix issues with token price fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^0.1.25",
+        "@balancer-labs/sdk": "^0.1.27",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-cdk-lib": "^2.32.1",
@@ -652,9 +652,9 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.25.tgz",
-      "integrity": "sha512-1FHcdHz2xzN+owkCQG9TsoUQbkmCU8mkVpKHYC9VZg0fTYe33sZKwgt2vvU+ylubBLTw4V7CnqohD5d/fxd1BQ==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.27.tgz",
+      "integrity": "sha512-JSkQZZUmMSCskCJP/Ic+sWT0GZ4wK0iRTopSxpsdRo5HuE2/uGmItnyi8kS5Gx84rPkn8fSLhvanbWgP6+HxQQ==",
       "dependencies": {
         "@balancer-labs/sor": "^4.0.1-beta.5",
         "@balancer-labs/typechain": "^1.0.0",
@@ -8778,9 +8778,9 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.25.tgz",
-      "integrity": "sha512-1FHcdHz2xzN+owkCQG9TsoUQbkmCU8mkVpKHYC9VZg0fTYe33sZKwgt2vvU+ylubBLTw4V7CnqohD5d/fxd1BQ==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.27.tgz",
+      "integrity": "sha512-JSkQZZUmMSCskCJP/Ic+sWT0GZ4wK0iRTopSxpsdRo5HuE2/uGmItnyi8kS5Gx84rPkn8fSLhvanbWgP6+HxQQ==",
       "requires": {
         "@balancer-labs/sor": "^4.0.1-beta.5",
         "@balancer-labs/typechain": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^0.1.25",
+    "@balancer-labs/sdk": "^0.1.27",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-cdk-lib": "^2.32.1",


### PR DESCRIPTION
Updates Balancer SDK to last version which incorporates https://github.com/balancer-labs/balancer-sdk/pull/165 which fixes issues with fetching APR's on L2's. 