### PR TITLE
Add check-wallet lambda that uses GET request + URL params + Caching

### DIFF
--- a/src/lambdas/check-wallet.spec.ts
+++ b/src/lambdas/check-wallet.spec.ts
@@ -1,0 +1,102 @@
+import nock from 'nock';
+import { handler } from './check-wallet';
+import { TRMAccountDetails } from '../types';
+
+nock.disableNetConnect();
+
+let trmResponse: TRMAccountDetails[] = [];
+
+const request = {
+  pathParameters: {
+    address: '0x0000000000000000000000000000000000000000',
+  },
+};
+
+describe('Wallet Check Lambda', () => {
+  it('Should return false for an address with no issues', async () => {
+    trmResponse = [
+      {
+        accountExternalId: null,
+        address: '0x0000000000000000000000000000000000000000',
+        addressRiskIndicators: [],
+        addressSubmitted: '0x0000000000000000000000000000000000000000',
+        chain: 'ethereum',
+        entities: [],
+        trmAppUrl:
+          'https://my.trmlabs.com/address/0x0000000000000000000000000000000000000000/eth',
+      },
+    ];
+    nock('https://api.trmlabs.com')
+      .post('/public/v2/screening/addresses')
+      .reply(200, trmResponse);
+    const response = await handler(request);
+    const body = JSON.parse(response.body);
+    expect(body.is_blocked).toBe(false);
+  });
+
+  it('Should return blocked for an address that has a Severe risk', async () => {
+    trmResponse = [
+      {
+        accountExternalId: null,
+        address: '0x0000000000000000000000000000000000000000',
+        addressRiskIndicators: [
+          {
+            category: 'Sanctions',
+            categoryId: '69',
+            categoryRiskScoreLevel: 15,
+            categoryRiskScoreLevelLabel: 'Severe',
+            incomingVolumeUsd:
+              '570037717.3324722239717737602882028941260267337',
+            outgoingVolumeUsd:
+              '573357789.82550046115536928143858188991303929335',
+            riskType: 'OWNERSHIP',
+            totalVolumeUsd: '1143395507.15797268512714304172678478403906602705',
+          },
+          {
+            category: 'Sanctions',
+            categoryId: '69',
+            categoryRiskScoreLevel: 15,
+            categoryRiskScoreLevelLabel: 'Severe',
+            incomingVolumeUsd: '0',
+            outgoingVolumeUsd:
+              '428172699.46703217102356766551565669942647220227',
+            riskType: 'COUNTERPARTY',
+            totalVolumeUsd: '428172699.46703217102356766551565669942647220227',
+          },
+        ],
+        addressSubmitted: '0x0000000000000000000000000000000000000000',
+        chain: 'ethereum',
+        entities: [
+          {
+            category: 'Sanctions',
+            categoryId: '69',
+            entity: 'Lazarus Group',
+            riskScoreLevel: 15,
+            riskScoreLevelLabel: 'Severe',
+            trmAppUrl:
+              'https://my.trmlabs.com/entities/trm/75624c42-157e-4a63-8f32-070b1d1fa4d4',
+            trmUrn: '/entity/manual/75624c42-157e-4a63-8f32-070b1d1fa4d4',
+          },
+          {
+            category: 'Hacked or Stolen Funds',
+            categoryId: '34',
+            entity: 'Ronin Bridge Hack - March 2022',
+            riskScoreLevel: 15,
+            riskScoreLevelLabel: 'Severe',
+            trmAppUrl:
+              'https://my.trmlabs.com/entities/trm/9145c0ff-1544-475f-8403-40840cb051e0',
+            trmUrn: '/entity/manual/9145c0ff-1544-475f-8403-40840cb051e0',
+          },
+        ],
+        trmAppUrl:
+          'https://my.trmlabs.com/address/0x0000000000000000000000000000000000000000/eth',
+      },
+    ];
+    nock('https://api.trmlabs.com')
+      .post('/public/v2/screening/addresses')
+      .reply(200, trmResponse);
+    const response = await handler(request);
+    const body = JSON.parse(response.body);
+    expect(body.is_blocked).toBe(true);
+  });
+});

--- a/src/lambdas/check-wallet.ts
+++ b/src/lambdas/check-wallet.ts
@@ -1,0 +1,76 @@
+import fetch from 'isomorphic-fetch';
+import { TRMAccountDetails, TRMEntity, TRMRiskIndicator } from '../types';
+
+const SANCTIONS_ENDPOINT =
+  'https://api.trmlabs.com/public/v2/screening/addresses';
+const { SANCTIONS_API_KEY } = process.env;
+
+function formatResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'OPTIONS,POST',
+    },
+    body,
+  };
+}
+
+export const handler = async (event: any = {}): Promise<any> => {
+  const address = event.pathParameters.address;
+  if (!address) {
+    return formatResponse(
+      400,
+      'Error: invalid request, you are missing the wallet address'
+    );
+  }
+
+  try {
+    const response = await fetch(SANCTIONS_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization:
+          'Basic ' +
+          Buffer.from(`${SANCTIONS_API_KEY}:${SANCTIONS_API_KEY}`).toString(
+            'base64'
+          ),
+      },
+      body: JSON.stringify([
+        {
+          address: address.toLowerCase(),
+          chain: 'ethereum',
+        },
+      ]),
+    });
+
+    const result: TRMAccountDetails[] = await response.json();
+
+    const riskIndicators: TRMRiskIndicator[] =
+      result[0]?.addressRiskIndicators || [];
+    const entities: TRMEntity[] = result[0]?.entities || [];
+
+    const hasSevereRisk = riskIndicators.some(
+      indicator => indicator.categoryRiskScoreLevelLabel === 'Severe'
+    );
+    const hasSevereEntity = entities.some(
+      entity => entity.riskScoreLevelLabel === 'Severe'
+    );
+
+    const isBlocked = hasSevereEntity || hasSevereRisk;
+
+    return formatResponse(
+      200,
+      JSON.stringify({
+        is_blocked: isBlocked,
+      })
+    );
+  } catch (e) {
+    console.log(
+      `Received error performing wallet check on address ${address}: ${e}`
+    );
+    return formatResponse(500, 'Unable to perform sanctions check');
+  }
+};


### PR DESCRIPTION
This PR adds caching to API Gateway for the wallet check function so that we don't hit TRM as much. Unfortunately when using POST parameters we couldn't add a caching layer. So instead I've made a new `/check-wallet/{address}` function that does the same thing as previously but caches based on address passed in. I created a new Lambda so we wouldn't have to deploy API + Frontend at the exact same time. 

I've set the cache to 60 minutes which is the max allowed by API Gateway. 

The firewall is still active for both this and the old /wallet-check lambda. After we've switched the frontend to use this new route I'll remove the wallet-check lambda. 

Tested via spamming the `/check-wallet` endpoint with a good address and a bad address and making sure it returns correct results for each, that only one invocation of the lambda is done, and that it still blocks after 100 requests in 5 minutes. 