### PR TITLE
Add sub-pool information to pool tokens.

### DIFF
--- a/appsync/pools/schema.graphql
+++ b/appsync/pools/schema.graphql
@@ -30,6 +30,8 @@
 	upperTarget: String
 	apr: AprBreakdown
 	isNew: Boolean
+	protocolYieldFeeCache: Float
+	priceRateProviders: [PriceRateProvider]
 }
 
 type PoolConnection {
@@ -62,6 +64,15 @@ type TokenTreePool @entity {
 	totalShares: String
 	mainIndex: Int
 	tokens: [PoolToken]
+}
+
+type PriceRateProvider @entity {
+	address: String
+	token: PriceRateProviderToken
+}
+
+type PriceRateProviderToken @entity {
+	address: String
 }
 
 type AprBreakdown @entity {

--- a/appsync/pools/schema.graphql
+++ b/appsync/pools/schema.graphql
@@ -52,6 +52,7 @@ type PoolToken @entity {
 
 type Token @entity {
 	pool: TokenTreePool
+	latestUSDPrice: String
 }
 
 type TokenTreePool @entity {

--- a/appsync/pools/schema.graphql
+++ b/appsync/pools/schema.graphql
@@ -47,6 +47,20 @@ type PoolToken @entity {
 	balance: String
 	# WeightedPool Only
 	weight: String
+	token: Token
+}
+
+type Token @entity {
+	pool: TokenTreePool
+}
+
+type TokenTreePool @entity {
+	id: String
+	address: String
+	poolType: String
+	totalShares: String
+	mainIndex: Int
+	tokens: [PoolToken]
 }
 
 type AprBreakdown @entity {

--- a/index.ts
+++ b/index.ts
@@ -204,7 +204,7 @@ export class BalancerPoolsAPI extends Stack {
           entry: join(__dirname, 'src', 'lambdas', 'decorate-pools.ts'),
           ...functionProps,
           memorySize: 2048,
-          timeout: Duration.seconds(60),
+          timeout: Duration.seconds(300),
           reservedConcurrentExecutions: 1,
         }
       );

--- a/index.ts
+++ b/index.ts
@@ -184,7 +184,7 @@ export class BalancerPoolsAPI extends Stack {
           entry: join(__dirname, 'src', 'lambdas', 'update-pools.ts'),
           ...functionProps,
           memorySize: 2048,
-          timeout: Duration.seconds(60),
+          timeout: Duration.seconds(600),
           reservedConcurrentExecutions: 1,
         }
       );
@@ -204,7 +204,7 @@ export class BalancerPoolsAPI extends Stack {
           entry: join(__dirname, 'src', 'lambdas', 'decorate-pools.ts'),
           ...functionProps,
           memorySize: 2048,
-          timeout: Duration.seconds(300),
+          timeout: Duration.seconds(600),
           reservedConcurrentExecutions: 1,
         }
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^0.1.39-beta.5",
+        "@balancer-labs/sdk": "^0.1.39-beta.12",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-cdk-lib": "^2.32.1",
@@ -653,11 +653,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.39-beta.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.5.tgz",
-      "integrity": "sha512-zoez7qC+f/UPK++wWpgrHaYwG2ZunCa+WjTBwyyhxDVxt0gIZ0UfdFqrSkPx2lN6YSqrVPLwqZzVbljuKfZrcA==",
+      "version": "0.1.39-beta.12",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.12.tgz",
+      "integrity": "sha512-dMgl/jL6iNTha8s0Pud2TQoMrDcqHg7D3wBv4OXNc0dvrCXKOBBMAf1X52ym6gGrtwJYJ+fQxlKxUkNwO/Aurg==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.1-beta.13",
+        "@balancer-labs/sor": "^4.0.1-beta.14",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
@@ -677,9 +677,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.0.1-beta.13",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.13.tgz",
-      "integrity": "sha512-lhJWzLEhGsYNyMyaArodZaP/3bHNnU5sYARishYJGlTD1l1a6xVFHyLShEhRzxHCmPeqR/qoSVElk4gI0JVbZQ==",
+      "version": "4.0.1-beta.14",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.14.tgz",
+      "integrity": "sha512-uT7pM4yfrWGpGZyWp3hac5uLGpmfYOfs5mV/tu+MDAgAEa4kVM+ra3fnIoHc8W09ijxFZHcfyalNB9LsoHH7IQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -8792,11 +8792,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.39-beta.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.5.tgz",
-      "integrity": "sha512-zoez7qC+f/UPK++wWpgrHaYwG2ZunCa+WjTBwyyhxDVxt0gIZ0UfdFqrSkPx2lN6YSqrVPLwqZzVbljuKfZrcA==",
+      "version": "0.1.39-beta.12",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.12.tgz",
+      "integrity": "sha512-dMgl/jL6iNTha8s0Pud2TQoMrDcqHg7D3wBv4OXNc0dvrCXKOBBMAf1X52ym6gGrtwJYJ+fQxlKxUkNwO/Aurg==",
       "requires": {
-        "@balancer-labs/sor": "^4.0.1-beta.13",
+        "@balancer-labs/sor": "^4.0.1-beta.14",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
@@ -8806,9 +8806,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.0.1-beta.13",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.13.tgz",
-      "integrity": "sha512-lhJWzLEhGsYNyMyaArodZaP/3bHNnU5sYARishYJGlTD1l1a6xVFHyLShEhRzxHCmPeqR/qoSVElk4gI0JVbZQ==",
+      "version": "4.0.1-beta.14",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.14.tgz",
+      "integrity": "sha512-uT7pM4yfrWGpGZyWp3hac5uLGpmfYOfs5mV/tu+MDAgAEa4kVM+ra3fnIoHc8W09ijxFZHcfyalNB9LsoHH7IQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^0.1.37",
+        "@balancer-labs/sdk": "^0.1.39-beta.5",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-cdk-lib": "^2.32.1",
@@ -22,6 +22,7 @@
         "dotenv": "^10.0.0",
         "ethers": "^5.3.0",
         "express": "^4.17.1",
+        "fishery": "^2.2.2",
         "isomorphic-fetch": "^3.0.0",
         "json-to-graphql-query": "^2.2.4",
         "lodash": "^4.17.21"
@@ -652,11 +653,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.37.tgz",
-      "integrity": "sha512-O/0mz38ieyIvGaJfOfJrv3p/33EnAzHzLYtQN8iccUm9U1lHaIopS+2tfsAsTOjpkr8CQEgkMJEWO4fx2ywM9Q==",
+      "version": "0.1.39-beta.5",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.5.tgz",
+      "integrity": "sha512-zoez7qC+f/UPK++wWpgrHaYwG2ZunCa+WjTBwyyhxDVxt0gIZ0UfdFqrSkPx2lN6YSqrVPLwqZzVbljuKfZrcA==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.1-beta.12",
+        "@balancer-labs/sor": "^4.0.1-beta.13",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
@@ -676,9 +677,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.0.1-beta.12",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.12.tgz",
-      "integrity": "sha512-RTb3cf/iPr/4HTMDvnArnwSp6p0Mx7B9J9O5h1+DPaC0VrFJani4T9x39J4v7RdAxtF39vnFpZ5uoVL8Sc28TQ==",
+      "version": "4.0.1-beta.13",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.13.tgz",
+      "integrity": "sha512-lhJWzLEhGsYNyMyaArodZaP/3bHNnU5sYARishYJGlTD1l1a6xVFHyLShEhRzxHCmPeqR/qoSVElk4gI0JVbZQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -4576,6 +4577,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/fishery": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.2.2.tgz",
+      "integrity": "sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==",
+      "dependencies": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -6373,6 +6382,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.set": {
       "version": "4.3.2",
@@ -8778,11 +8792,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.37.tgz",
-      "integrity": "sha512-O/0mz38ieyIvGaJfOfJrv3p/33EnAzHzLYtQN8iccUm9U1lHaIopS+2tfsAsTOjpkr8CQEgkMJEWO4fx2ywM9Q==",
+      "version": "0.1.39-beta.5",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.5.tgz",
+      "integrity": "sha512-zoez7qC+f/UPK++wWpgrHaYwG2ZunCa+WjTBwyyhxDVxt0gIZ0UfdFqrSkPx2lN6YSqrVPLwqZzVbljuKfZrcA==",
       "requires": {
-        "@balancer-labs/sor": "^4.0.1-beta.12",
+        "@balancer-labs/sor": "^4.0.1-beta.13",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
@@ -8792,9 +8806,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.0.1-beta.12",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.12.tgz",
-      "integrity": "sha512-RTb3cf/iPr/4HTMDvnArnwSp6p0Mx7B9J9O5h1+DPaC0VrFJani4T9x39J4v7RdAxtF39vnFpZ5uoVL8Sc28TQ==",
+      "version": "4.0.1-beta.13",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.13.tgz",
+      "integrity": "sha512-lhJWzLEhGsYNyMyaArodZaP/3bHNnU5sYARishYJGlTD1l1a6xVFHyLShEhRzxHCmPeqR/qoSVElk4gI0JVbZQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -11549,6 +11563,14 @@
         "path-exists": "^4.0.0"
       }
     },
+    "fishery": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/fishery/-/fishery-2.2.2.tgz",
+      "integrity": "sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==",
+      "requires": {
+        "lodash.mergewith": "^4.6.2"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -12880,6 +12902,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.set": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^0.1.39-beta.5",
+    "@balancer-labs/sdk": "^0.1.39-beta.12",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-cdk-lib": "^2.32.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^0.1.37",
+    "@balancer-labs/sdk": "^0.1.39-beta.5",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-cdk-lib": "^2.32.1",
@@ -35,6 +35,7 @@
     "dotenv": "^10.0.0",
     "ethers": "^5.3.0",
     "express": "^4.17.1",
+    "fishery": "^2.2.2",
     "isomorphic-fetch": "^3.0.0",
     "json-to-graphql-query": "^2.2.4",
     "lodash": "^4.17.21"

--- a/src/lambdas/decorate-pools.ts
+++ b/src/lambdas/decorate-pools.ts
@@ -19,7 +19,7 @@ export const handler = async (): Promise<any> => {
     const pools = await getPools(chainId);
     log(`Decoracting ${pools.length} pools for chain ${chainId}`);
     const decorateStartTime = Date.now();
-    const poolDecorator = new PoolDecorator(pools, chainId);
+    const poolDecorator = new PoolDecorator(pools, { chainId });
     const decoratedPools = await poolDecorator.decorate(tokens);
     log(`Decorated ${decoratedPools.length} pools`);
     const modifiedPools = decoratedPools.filter(

--- a/src/lambdas/update-pools.ts
+++ b/src/lambdas/update-pools.ts
@@ -29,10 +29,10 @@ export const handler = async (): Promise<any> => {
     const poolDecorator = new PoolDecorator(pools, { poolsToDecorate: changedPools, chainId: chainId });
     const decoratedPools = await poolDecorator.decorate(currentTokens);
     log(`Decorated ${decoratedPools.length} pools`);
-    log(`Saving ${changedPools.length} pools for chain ${chainId} to database`);
-    await updatePools(changedPools);
+    log(`Saving ${decoratedPools.length} pools for chain ${chainId} to database`);
+    await updatePools(decoratedPools);
     log(`Saved pools. Fetching Tokens for pools`);
-    const tokenAddresses = getTokenAddressesFromPools(changedPools);
+    const tokenAddresses = getTokenAddressesFromPools(decoratedPools);
     log(
       `Found ${tokenAddresses.length} tokens in pools on chain ${chainId}. Filtering by known tokens`
     );

--- a/src/pools/pool.decorator.ts
+++ b/src/pools/pool.decorator.ts
@@ -28,7 +28,7 @@ export class PoolDecorator {
   poolsRepositories: BalancerDataRepositories;
   networkConfig: BalancerNetworkConfig;
 
-  constructor(public pools: Pool[], private options: PoolDecoratorOptions) {}
+  constructor(public pools: Pool[], private options: PoolDecoratorOptions = {}) {}
 
   public async decorate(tokens: Token[]): Promise<Pool[]> {
     log('------- START Decorating pools --------');
@@ -99,11 +99,14 @@ export class PoolDecorator {
     }
 
     try {
-      await poolService.setTotalLiquidity();
-      await poolService.setApr();
-      await poolService.setVolumeSnapshot();
-      await poolService.expandPool();
-      poolService.setIsNew();
+      await Promise.all([
+        poolService.setTotalLiquidity(),
+        poolService.setApr(),
+        poolService.setVolumeSnapshot(),
+        poolService.expandPool(),
+      ]);
+
+      poolService.setIsNew()
     } catch (e) {
       console.log(`Failed to decorate pool ${pool.id} Error is: ${e}. Pool is: ${util.inspect(
         pool,

--- a/src/pools/pool.service.spec.ts
+++ b/src/pools/pool.service.spec.ts
@@ -1,0 +1,161 @@
+
+/** expandPool test:
+ * Need to get an example of an unexpanded pool with other pool ID's. 
+ * Then add those pools to the SDK pools find function
+ * Then run expand on the first pool and make sure the subpools are correctly added to it
+ * 
+ * Example pool: 0xb9bd68a77ccf8314c0dfe51bc291c77590c4e9e6000200000000000000000385
+ * wstETH / bb-a-USD
+ * It doesn't have the pool ID on the token, but I can find pools by that address
+ * and that works well enough. Then just add them on in exactly the same way as the frontend does it. 
+ * Only need some of the pool fields, not all of them. 
+ */
+
+import { factories } from "../../test/factories";
+import { Pool, PoolType, PoolToken, TokenTreePool } from "../../src/types";
+import { PoolService } from "../../src/pools/pool.service";
+import { 
+  BalancerDataRepositories, 
+  BalancerSDK, 
+  BalancerSdkConfig, 
+  PoolsStaticRepository,
+  Pool as SDKPool,
+} from "@balancer-labs/sdk";
+import * as _ from 'lodash';
+import { BoostedInfo, LinearParams } from "../../test/factories/pools";
+
+jest.unmock('@balancer-labs/sdk');
+
+const balancerConfig: BalancerSdkConfig = {
+  network: 1,
+  rpcUrl: '',
+};
+const balancerSdk = new BalancerSDK(balancerConfig);
+const dataRepositories = balancerSdk.data;
+const networkConfig = balancerSdk.networkConfig;
+
+function getPoolsRepository(pools: Pool[]) {
+  const poolProvider = new PoolsStaticRepository(pools as SDKPool[]);
+  const poolsRepositories: BalancerDataRepositories = {
+    ...dataRepositories,
+    ...{
+      pools: poolProvider,
+    },
+  };
+  return poolsRepositories;
+}
+
+describe('Pool Service', () => {
+  describe('expandPool', () => {
+    let linearPools: Pool[];
+    let boostedPoolInfo: BoostedInfo;
+    let boostedPool: Pool;
+
+    beforeAll(() => {
+      const linearPoolDescriptions: LinearParams = {
+        pools: [
+          {
+            tokens: {
+              wrappedSymbol: 'aDAI',
+              mainSymbol: 'DAI',
+            },
+            balance: '1000000',
+          },
+          {
+            tokens: {
+              wrappedSymbol: 'aUSDC',
+              mainSymbol: 'USDC',
+            },
+            balance: '500000',
+          },
+          {
+            tokens: {
+              wrappedSymbol: 'aUSDT',
+              mainSymbol: 'USDT',
+            },
+            balance: '500000',
+          },
+        ]
+      };
+      
+      const linearPoolInfo = factories.linearPools.transient(linearPoolDescriptions).build();
+      linearPools = linearPoolInfo.linearPools;
+      
+      boostedPoolInfo = factories.boostedPool
+        .transient({
+          linearPoolInfo,
+          rootId: 'phantom_boosted_1',
+          rootAddress: 'address_phantom_boosted_1',
+        })
+        .build();
+      boostedPool = boostedPoolInfo.rootPool;
+    });
+
+    it('Should return a pool without any subpools as exactly the same', async () => {
+      const pool: Pool =  factories.poolBase.build();
+      const poolService = new PoolService(pool, networkConfig, getPoolsRepository([]));
+      await poolService.expandPool();
+      expect(poolService.pool).toEqual(pool);
+    });
+    
+    it('Should add immediate sub-pool information to a pool', async () => {
+      const poolService = new PoolService(boostedPool, networkConfig, getPoolsRepository([...linearPools, boostedPool]));
+      await poolService.expandPool();
+      const tokens = poolService.pool.tokens;
+      expect(tokens.length).toBe(4);
+      expect(tokens[0].token?.pool).toBeTruthy()
+      const tokenTreePoolItems = [
+        'id', 'address', 'poolType', 'totalShares', 'mainIndex'
+      ]
+      expect(tokens[0].token?.pool).toMatchObject(_.pick(linearPools[0], tokenTreePoolItems));
+      expect(tokens[1].token?.pool).toMatchObject(_.pick(linearPools[1], tokenTreePoolItems));
+      expect(tokens[2].token?.pool).toMatchObject(_.pick(linearPools[2], tokenTreePoolItems));
+      expect(tokens[3].token).toBeFalsy(); // This is the BPT token, it shouldn't add a subpool of itself
+    });
+
+    it('Should add multiple layers deep of sub-pool to the pool', async () => {
+      const stableLinearPoolDescription: LinearParams = {
+        pools: [
+          {
+            tokens: {
+              wrappedSymbol: 'aSTABLE',
+              mainSymbol: 'STABLE',
+            },
+            balance: '500000',
+          },
+        ],
+      };
+      const linearPoolInfo = factories.linearPools.transient(stableLinearPoolDescription).build();
+      const stableLinearPool = linearPoolInfo.linearPools[0];
+      const boostedMetaInfo = factories.boostedMetaPool
+        .transient({
+          rootId: 'id-parent',
+          rootAddress: 'address-parent',
+          rootBalance: '1000000',
+          linearPoolInfo,
+          boostedPoolInfo,
+        })
+        .build();
+
+      const boostedMetaPool: Pool = boostedMetaInfo.rootInfo.pool;
+
+      const poolService = new PoolService(boostedMetaPool, networkConfig, getPoolsRepository([...linearPools, boostedPool, stableLinearPool, boostedMetaPool]));
+      await poolService.expandPool();
+      const tokens = poolService.pool.tokens;
+      expect(tokens.length).toBe(3);
+      expect(tokens[0].token?.pool).toBeTruthy()
+      const tokenTreePoolItems = [
+        'id', 'address', 'poolType', 'totalShares', 'mainIndex'
+      ]
+      expect(tokens[0].token?.pool).toMatchObject(_.pick(boostedPool, tokenTreePoolItems));
+      expect(tokens[1].token?.pool).toMatchObject(_.pick(stableLinearPool, tokenTreePoolItems));
+      expect(tokens[2].token).toBeFalsy(); // This is the BPT token, it shouldn't add a subpool of itself
+      const boostedPoolTokens: PoolToken[] = tokens[0].token?.pool?.tokens || [];
+      expect(boostedPoolTokens[0].token?.pool).toMatchObject(_.pick(linearPools[0], tokenTreePoolItems));
+      expect(boostedPoolTokens[1].token?.pool).toMatchObject(_.pick(linearPools[1], tokenTreePoolItems));
+      expect(boostedPoolTokens[2].token?.pool).toMatchObject(_.pick(linearPools[2], tokenTreePoolItems));
+      expect(boostedPoolTokens[3].token).toBeFalsy(); // This is the BPT token, it shouldn't add a subpool of itself
+    });
+
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import { Pool as SDKPool, SwapV2, Token as SDKToken } from '@balancer-labs/sdk';
+import { Pool as SDKPool, PoolType, SwapV2, Token as SDKToken, PoolToken as SDKPoolToken } from '@balancer-labs/sdk';
+export { PoolType } from '@balancer-labs/sdk';
 
 export interface Order {
   sellToken: string;
@@ -12,6 +13,22 @@ export interface Token extends SDKToken {
   chainId: number;
   lastUpdate?: number;
   noPriceData?: boolean;
+}
+
+export interface TokenTreePool {
+  id: string;
+  address: string;
+  poolType: PoolType;
+  totalShares: string;
+  mainIndex: number;
+  tokens?: PoolToken[];
+}
+
+export interface PoolToken extends SDKPoolToken {
+  token?: {
+    pool: TokenTreePool | null;
+    latestUSDPrice?: string;
+  };
 }
 
 export interface SerializedSwapInfo {
@@ -29,6 +46,7 @@ export interface SerializedSwapInfo {
 
 export interface Pool extends SDKPool {
   chainId: number;
+  tokens: PoolToken[];
   graphData?: {
     totalLiquidity?: string;
   };
@@ -36,8 +54,7 @@ export interface Pool extends SDKPool {
   managementFee?: string;
   mainIndex?: number;
   wrappedIndex?: number;
-  lowerTarget?: string;
-  upperTarget?: string;
+  proportionOfParent?: string;
 }
 
 export interface SorRequest {

--- a/test/factories/index.ts
+++ b/test/factories/index.ts
@@ -1,0 +1,6 @@
+import * as sor from './sor';
+import * as pools from './pools';
+
+const factories = { ...sor, ...pools };
+
+export { factories };

--- a/test/factories/named-tokens.ts
+++ b/test/factories/named-tokens.ts
@@ -1,0 +1,71 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const namedTokens: Record<string, any> = {
+  wstETH: {
+    address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+    decimals: 18,
+  },
+  wETH: {
+    address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    decimals: 18,
+  },
+  wBTC: {
+    address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+    decimals: 8,
+  },
+  BADGER: {
+    address: '0x3472a5a71965499acd81997a54bba8d852c6e53d',
+    decimals: 18,
+  },
+  DAI: {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    decimals: 18,
+  },
+  aDAI: {
+    address: '0x02d60b84491589974263d922d9cc7a3152618ef6',
+    decimals: 18,
+  },
+  bDAI: {
+    address: '0x804cdb9116a10bb78768d3252355a1b18067bf8f',
+    decimals: 18,
+  },
+  USDC: {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    decimals: 6,
+  },
+  aUSDC: {
+    address: '0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de',
+    decimals: 18,
+  },
+  bUSDC: {
+    address: '0x9210f1204b5a24742eba12f710636d76240df3d0',
+    decimals: 18,
+  },
+  USDT: {
+    address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    decimals: 6,
+  },
+  aUSDT: {
+    address: '0xf8fd466f12e236f4c96f7cce6c79eadb819abf58',
+    decimals: 18,
+  },
+  bUSDT: {
+    address: '0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c',
+    decimals: 18,
+  },
+  BAL: {
+    address: '0xba100000625a3754423978a60c9317c58a424e3D'.toLowerCase(),
+    decimals: 18,
+  },
+  auraBAL: {
+    address: '0x616e8bfa43f920657b3497dbf40d6b1a02d4608d',
+    decimals: 18,
+  },
+  B80BAL20WETH: {
+    address: '0x5c6ee304399dbdb9c8ef030ab642b10820db8f56',
+    decimals: 18,
+  },
+  graviAura: {
+    address: '0xBA485b556399123261a5F9c95d413B4f93107407',
+    decimals: 18,
+  },
+};

--- a/test/factories/pools.ts
+++ b/test/factories/pools.ts
@@ -1,0 +1,412 @@
+import { Factory } from 'fishery';
+import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
+
+import { formatAddress, formatId } from '../lib/utils';
+import { Zero, WeiPerEther } from '@ethersproject/constants';
+import { Pool, PoolType, PoolToken } from '../../src/types';
+import { namedTokens } from './named-tokens';
+
+export type PoolParams = {
+  type: PoolType;
+}
+
+type LinearTokens = {
+  wrappedSymbol: string;
+  mainSymbol: string;
+};
+
+export type LinearParams = {
+  pools: {
+    tokens: LinearTokens;
+    balance: string;
+  }[];
+};
+
+export type LinearInfo = {
+  linearPools: Pool[];
+  totalBalance: string;
+  mainTokens: PoolToken[];
+  wrappedTokens: PoolToken[];
+  linearPoolTokens: PoolToken[];
+};
+
+export interface ComposableStableParams {
+  id: string;
+  symbol: string;
+  address: string;
+  childTokens: PoolToken[];
+  tokenbalance: string;
+}
+
+export type ComposableStableInfo = {
+  pool: Pool;
+  poolToken: PoolToken;
+};
+
+export interface BoostedParams {
+  linearPoolInfo: LinearInfo;
+  rootId: string;
+  rootAddress: string;
+  rootBalance: string;
+}
+
+export interface BoostedInfo extends LinearInfo {
+  rootPool: Pool;
+  rootPoolToken: PoolToken;
+}
+
+export interface BoostedMetaParams {
+  boostedPoolInfo: BoostedInfo;
+  linearPoolInfo: LinearInfo;
+  rootId: string;
+  rootAddress: string;
+  rootBalance: string;
+}
+
+export interface ChildBoostedInfo extends BoostedInfo {
+  proportion: string;
+}
+
+export interface BoostedMetaInfo {
+  rootInfo: ComposableStableInfo;
+  boostedPoolInfo: ChildBoostedInfo;
+  linearPoolInfo: LinearInfo;
+}
+
+export interface BoostedMetaBigParams {
+  rootId: string;
+  rootAddress: string;
+  rootBalance: string;
+  childPools: BoostedParams[];
+}
+
+export interface BoostedMetaBigInfo {
+  rootPool: Pool;
+  rootPoolToken: PoolToken;
+  childPoolsInfo: ChildBoostedInfo[];
+  childPools: Pool[];
+}
+
+const poolBase = Factory.define<Pool, PoolParams>(
+  ({ params, afterBuild }) => {
+    afterBuild((pool) => {
+      pool.tokensList = pool.tokens.map((t) => t.address);
+    });
+
+    const type = params.poolType || PoolType.Weighted;
+
+    const tokens = params.tokens || [
+      poolToken.transient({ symbol: 'wETH' }).build(),
+      poolToken.transient({ symbol: 'wBTC' }).build(),
+    ];
+
+    return {
+      id: '0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e',
+      address: '0xa6f548df93de924d73be7d25dc02554c6bd66db5',
+      name: 'Default Pool',
+      chainId: 1,
+      poolType: type,
+      poolTypeVersion: 1,
+      protocolYieldFeeCache: '0',
+      swapFee: '0.001',
+      swapEnabled: true,
+      tokens,
+      tokensList: [],
+      totalWeight: '1',
+      totalShares: '1',
+      totalLiquidity: '0',
+      lowerTarget: '',
+      upperTarget: '',
+    };
+  }
+);
+
+const poolToken = Factory.define<PoolToken>(({ transientParams }) => {
+  const { symbol, balance = '1', weight = '1', address } = transientParams;
+  let namedToken = namedTokens[symbol];
+  if (!namedToken) {
+    namedToken = {};
+    namedToken.address = formatAddress(address ?? `address_${symbol}`);
+    namedToken.decimals = 18;
+  }
+  return {
+    ...namedToken,
+    balance,
+    priceRate: '1',
+    weight,
+    symbol,
+  };
+});
+
+/*
+Create a set of Linear pools and associated tokens:
+LinearPools consisting of wrappedToken, mainToken, composableBpt
+*/
+const linearPools = Factory.define<LinearInfo, LinearParams>(
+  ({ transientParams }) => {
+    const { pools } =
+      transientParams;
+    if (pools === undefined) throw new Error('Need linear pool params');
+    const linearPools: Pool[] = [];
+    const mainTokens: PoolToken[] = [];
+    const wrappedTokens: PoolToken[] = [];
+    const linearPoolTokens: PoolToken[] = [];
+
+    const totalBalance = pools.reduce(
+      (total: BigNumber, pool) => total.add(pool.balance),
+      Zero
+    );
+    pools?.forEach((pool) => {
+      const poolAddress = formatAddress(
+        `address-${pool.tokens.mainSymbol}_${pool.tokens.wrappedSymbol}`
+      );
+      const mainToken = poolToken
+        .transient({
+          symbol: pool.tokens.mainSymbol,
+          balance: '1000000',
+        })
+        .build();
+      const wrappedToken = poolToken
+        .transient({
+          symbol: pool.tokens.wrappedSymbol,
+          balance: '9711834',
+        })
+        .build();
+      const composableBptToken = poolToken
+        .transient({
+          symbol: `b${pool.tokens.mainSymbol}_${pool.tokens.wrappedSymbol}`,
+          balance: '5192296829399898',
+          address: poolAddress,
+        })
+        .build();
+      const linearPool = poolBase.build({
+        id: formatId(
+          `id-${pool.tokens.mainSymbol}_${pool.tokens.wrappedSymbol}`
+        ),
+        address: poolAddress,
+        poolType: PoolType.AaveLinear,
+        tokens: [mainToken, wrappedToken, composableBptToken],
+        wrappedIndex: 1,
+        mainIndex: 0,
+        tokensList: [
+          mainToken.address,
+          wrappedToken.address,
+          composableBptToken.address,
+        ],
+        lowerTarget: '1',
+        upperTarget: '1',
+      });
+      // Update the pool token to have the expected balance set in input
+      composableBptToken.balance = pool.balance;
+      linearPoolTokens.push(composableBptToken);
+      mainTokens.push(mainToken);
+      wrappedTokens.push(wrappedToken);
+      linearPools.push({
+        ...linearPool,
+      });
+    });
+    return {
+      linearPools,
+      totalBalance: totalBalance.toString(),
+      mainTokens,
+      wrappedTokens,
+      linearPoolTokens,
+    };
+  }
+);
+
+/*
+Create and return a composableStable pool (with composableBpt) and token.
+*/
+const composableStablePool = Factory.define<
+  ComposableStableInfo,
+  ComposableStableParams
+>(({ transientParams }) => {
+  const { id, address, symbol, childTokens, tokenbalance } = transientParams;
+  // Create composableStable BPT
+  const composableBptToken = poolToken
+    .transient({
+      symbol,
+      balance: '5192296829399898', // need composableBpt balance for pool
+      address,
+    })
+    .build();
+
+  // Create composableStable pool
+  const pool = poolBase.build({
+    poolType: PoolType.ComposableStable,
+    id,
+    address,
+    totalWeight: undefined,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    tokens: [...childTokens!, composableBptToken],
+    amp: '1',
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  composableBptToken.balance = tokenbalance!;
+
+  return {
+    pool: { ...pool, proportionOfParent: '1' },
+    poolToken: composableBptToken,
+  };
+});
+
+/*
+Check a boostedPool, a composableStable with all constituents being Linear.
+Also creates associated LinearPools consisting of wrappedToken, mainToken, composableBpt.
+*/
+const boostedPool = Factory.define<BoostedInfo, BoostedParams>(
+  ({ transientParams }) => {
+    const {
+      linearPoolInfo,
+      rootAddress = 'address_root',
+      rootId = 'id_root',
+      rootBalance = '1000000',
+    } = transientParams;
+    if (!linearPoolInfo) throw new Error('Boosted Pool requires linear Pool Info');
+
+    const rootPoolParams = {
+      id: formatId(rootId),
+      symbol: 'bRootPool',
+      address: formatAddress(rootAddress),
+      childTokens: linearPoolInfo.linearPoolTokens,
+      tokenbalance: rootBalance,
+    };
+    const rootInfo = composableStablePool.build(
+      {},
+      { transient: rootPoolParams }
+    );
+
+    return {
+      rootPool: rootInfo.pool,
+      rootPoolToken: rootInfo.poolToken,
+      totalBalance: rootBalance,
+      linearPools: linearPoolInfo.linearPools,
+      mainTokens: linearPoolInfo.mainTokens,
+      wrappedTokens: linearPoolInfo.wrappedTokens,
+      linearPoolTokens: linearPoolInfo.linearPoolTokens,
+    };
+  }
+);
+
+/*
+Check a boostedMetaPool, a composableStable with one Linear and one boosted.
+Also creates associated boosted and LinearPools consisting of wrappedToken, mainToken, composableBpt.
+*/
+const boostedMetaPool = Factory.define<BoostedMetaInfo, BoostedMetaParams>(
+  ({ transientParams }) => {
+    const {
+      boostedPoolInfo,
+      linearPoolInfo,
+      rootAddress,
+      rootId,
+      rootBalance,
+    } = transientParams;
+
+    if (boostedPoolInfo === undefined || linearPoolInfo === undefined)
+      throw Error('Missing Pool Params.');
+
+    const rootTokenBalanceBoosted = BigNumber.from(
+      boostedPoolInfo.totalBalance
+    );
+    const rootTokenBalanceLiner = BigNumber.from(
+      linearPoolInfo.totalBalance
+    );
+    const totalTokenBalance = rootTokenBalanceBoosted.add(
+      rootTokenBalanceLiner
+    );
+
+    const childBoostedProportion = formatFixed(
+      rootTokenBalanceBoosted
+        .mul(BigNumber.from(WeiPerEther))
+        .div(totalTokenBalance),
+      18
+    );
+
+    const childBoostedBpt = boostedPoolInfo.rootPoolToken;
+
+    const rootPoolParams = {
+      id: formatId(rootId as string),
+      symbol: 'rootPool',
+      address: formatAddress(rootAddress as string),
+      childTokens: [childBoostedBpt, ...linearPoolInfo.linearPoolTokens],
+      tokenbalance: rootBalance,
+    };
+    const rootInfo = composableStablePool.build(
+      {},
+      { transient: rootPoolParams }
+    );
+
+    return {
+      rootInfo,
+      boostedPoolInfo: {
+        ...boostedPoolInfo,
+        proportion: childBoostedProportion,
+      },
+      linearPoolInfo,
+    };
+  }
+);
+
+/*
+Check a boostedMetaBigPool, a composableStable with two boosted.
+Also creates associated boosted and LinearPools consisting of wrappedToken, mainToken, composableBpt.
+*/
+const boostedMetaBigPool = Factory.define<
+  BoostedMetaBigInfo,
+  BoostedMetaBigParams
+>(({ transientParams }) => {
+  const childPoolsInfo: ChildBoostedInfo[] = [];
+  // These will be used in parent pool
+  const childPoolTokens: PoolToken[] = [];
+  // These will include composableStables and linear pools
+  const childPools: Pool[] = [];
+
+  if (transientParams.childPools === undefined)
+    throw new Error(`Can't create boostedMetaBig without child pools.`);
+
+  // TO DO - need proportions
+  let totalTokenBalance = Zero;
+  for (let i = 0; i < transientParams.childPools.length; i++) {
+    const balance = transientParams.childPools[i].rootBalance;
+    totalTokenBalance = totalTokenBalance.add(balance);
+  }
+
+  // Create each child boostedPool
+  for (let i = 0; i < transientParams.childPools.length; i++) {
+    const childPool = transientParams.childPools[i];
+    const proportion = formatFixed(
+      BigNumber.from(childPool.rootBalance)
+        .mul(WeiPerEther)
+        .div(totalTokenBalance),
+      18
+    );
+    childPool.parentsProportion = proportion;
+    const childBoosted = boostedPool.transient(childPool).build();
+    childPoolsInfo.push({ ...childBoosted, proportion });
+    childPools.push(childBoosted.rootPool, ...childBoosted.linearPools);
+    childPoolTokens.push(childBoosted.rootPoolToken);
+  }
+
+  const composableParams = {
+    id: formatId(transientParams.rootId as string),
+    symbol: 'parentComposable',
+    address: formatAddress(transientParams.rootAddress as string),
+    childTokens: childPoolTokens,
+    tokenbalance: transientParams.rootBalance,
+  };
+  const rootInfo = composableStablePool.build(
+    {},
+    { transient: composableParams }
+  );
+
+  return {
+    rootPool: rootInfo.pool,
+    rootPoolToken: rootInfo.poolToken,
+    childPoolsInfo,
+    childPools,
+  };
+});
+
+export { poolBase, linearPools, boostedPool, boostedMetaPool, boostedMetaBigPool };

--- a/test/factories/sor.ts
+++ b/test/factories/sor.ts
@@ -1,0 +1,80 @@
+import { Factory } from 'fishery';
+import {
+  SubgraphPoolBase,
+  SubgraphToken,
+  SwapInfo,
+  SwapV2,
+} from '@balancer-labs/sor';
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatAddress } from '../lib/utils';
+import { namedTokens } from './named-tokens';
+
+const swapV2 = Factory.define<SwapV2>(() => ({
+  poolId: '0xe2957c36816c1033e15dd3149ddf2508c3cfe79076ce4bde6cb3ecd34d4084b4',
+  assetInIndex: 0,
+  assetOutIndex: 1,
+  amount: '1000000000000000000',
+  userData: '0x',
+}));
+
+const swapInfo = Factory.define<SwapInfo>(() => ({
+  swaps: [swapV2.build()],
+  tokenAddresses: [
+    '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+    '0x0000000000000000000000000000000000000000',
+  ],
+  tokenIn: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+  tokenOut: '0x0000000000000000000000000000000000000000',
+  marketSp: '1',
+  swapAmount: BigNumber.from('1000000000000000000'),
+  swapAmountForSwaps: BigNumber.from('1000000000000000000'),
+  returnAmount: BigNumber.from('1000000000000000000'),
+  returnAmountFromSwaps: BigNumber.from('1000000000000000000'),
+  returnAmountConsideringFees: BigNumber.from('1000000000000000000'),
+}));
+
+const subgraphToken = Factory.define<SubgraphToken>(({ transientParams }) => {
+  const { symbol, balance = '1', weight = '1', address } = transientParams;
+  let namedToken = namedTokens[symbol];
+  if (!namedToken) {
+    namedToken = {};
+    namedToken.address = formatAddress(address ?? `address_${symbol}`);
+    namedToken.decimals = 18;
+  }
+  return {
+    ...namedToken,
+    balance,
+    priceRate: '1',
+    weight,
+    symbol,
+  };
+});
+
+const subgraphPoolBase = Factory.define<SubgraphPoolBase>(
+  ({ params, afterBuild }) => {
+    afterBuild((pool) => {
+      pool.tokensList = pool.tokens.map((t) => t.address);
+    });
+
+    const type = params.poolType || 'Weighted';
+
+    const tokens = params.tokens || [
+      subgraphToken.transient({ symbol: 'wETH' }).build(),
+      subgraphToken.transient({ symbol: 'wBTC' }).build(),
+    ];
+
+    return {
+      id: '0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e',
+      address: '0xa6f548df93de924d73be7d25dc02554c6bd66db5',
+      poolType: type,
+      swapFee: '0.001',
+      swapEnabled: true,
+      tokens,
+      tokensList: [],
+      totalWeight: '1',
+      totalShares: '1',
+    };
+  }
+);
+
+export { swapInfo, swapV2, subgraphPoolBase, subgraphToken };

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -1,0 +1,11 @@
+import { formatBytes32String } from "@ethersproject/strings";
+
+export const formatAddress = (text: string): string => {
+  if (text.match(/^(0x)?[0-9a-fA-F]{40}$/)) return text; // Return text if it's already a valid address
+  return formatBytes32String(text).slice(0, 42);
+};
+
+export const formatId = (text: string): string => {
+  if (text.match(/^(0x)?[0-9a-fA-F]{64}$/)) return text; // Return text if it's already a valid id
+  return formatBytes32String(text);
+};

--- a/test/mocks/pools.ts
+++ b/test/mocks/pools.ts
@@ -12,6 +12,8 @@ const pools: Pool[] = [
     wrappedIndex: 0,
     swapEnabled: true,
     poolType: PoolType.Weighted,
+    poolTypeVersion: 1,
+    protocolYieldFeeCache: '',
     address: '0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5',
     totalWeight: '1',
     totalLiquidity: '12345',


### PR DESCRIPTION
- Add new function to decorate pools that finds tokens that are sub-pools and adds their subpool information to the main pool. This is so all this information can be fetched in one request from the API instead of assembled client side.
- Add new test pool factory using fishery to create mock pools for the pool decorator tests. This is mostly based off the SDK pool factory but with a normal Pool type instead of SubgraphPool / SubgraphPoolToken. 

This is built on top of #131  because some of the pool update optimizations are needed for this PR (specifically that PR introduces only some pools updating and in this PR I added decoration after updating so that subpools never disappear after an update but before a decoration). 