### PR TITLE
Optimize Pool Updating

### DIFF
--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -70,7 +70,7 @@ export const POOL_SCHEMA: Schema = {
 
   isNew: { type: 'Boolean', static: false},
 
-  tokens: { type: 'Object', static: false},
+  tokens: { type: 'Array', static: false},
   tokensList: { type: 'Array', static: false },
 
   swapEnabled: { type: 'Boolean', static: false },

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -57,34 +57,74 @@ export const TOKENS_TABLE_SCHEMA = {
  * BigNumber: Saved as a number in DynamoDB, but a String in JS
  */
 export const POOL_SCHEMA: Schema = {
-  swapEnabled: { type: 'Boolean' },
-  swapFee: { type: 'BigDecimal' },
+  id: { type: 'String', static: true },
+  chainId: { type: 'Int', static: true },
+  poolType: { type: 'String', static: true },
+  poolTypeVersion: { type: 'Int', static: true },
 
-  totalWeight: { type: 'BigDecimal' },
-  totalSwapVolume: { type: 'BigDecimal' },
-  totalSwapFee: { type: 'BigDecimal' },
-  totalLiquidity: { type: 'BigDecimal' },
-  totalShares: { type: 'BigDecimal' },
+  name: { type: 'String', static: false },
+  address: { type: 'String', static: true },
+  owner: { type: 'String', static: false },
+  factory: { type: 'String', static: true },
+  symbol: { type: 'String', static: true },
 
-  volumeSnapshot: { type: 'BigDecimal' },
+  isNew: { type: 'Boolean', static: false},
 
-  createTime: { type: 'Int' },
-  swapsCount: { type: 'BigInt' },
-  holdersCount: { type: 'BigInt' },
+  tokens: { type: 'Object', static: false},
+  tokensList: { type: 'Array', static: false },
+  tokenAddresses: { type: 'Array', static: false },
+
+  principalToken: { type: 'String', static: true },
+  baseToken: { type: 'String', static: true },
+
+  swapEnabled: { type: 'Boolean', static: false },
+  swapFee: { type: 'BigDecimal', static: false },
+
+  protocolYieldFeeCache: { type: 'String', static: false},
+
+  totalWeight: { type: 'BigDecimal', static: true },
+  totalSwapVolume: { type: 'BigDecimal', static: false },
+  totalSwapFee: { type: 'BigDecimal', static: false },
+  totalLiquidity: { type: 'BigDecimal', static: false },
+  totalShares: { type: 'BigDecimal', static: false },
+
+  volumeSnapshot: { type: 'BigDecimal', static: false },
+
+  createTime: { type: 'Int', static: true },
+  swapsCount: { type: 'BigInt', static: false },
+  holdersCount: { type: 'BigInt', static: false },
 
   // StablePool Only
-  amp: { type: 'BigInt' },
+  amp: { type: 'BigInt', static: false },
 
   // ConvergentCurvePool (Element) Only
-  expiryTime: { type: 'BigInt' },
-  unitSeconds: { type: 'BigInt' },
+  expiryTime: { type: 'BigInt', static: true },
+  unitSeconds: { type: 'BigInt', static: true },
 
   //InvestmentPool Only
-  managementFee: { type: 'BigDecimal' },
+  managementFee: { type: 'BigDecimal', static: false },
 
   // LinearPool only
-  mainIndex: { type: 'Int' },
-  wrappedIndex: { type: 'Int' },
-  lowerTarget: { type: 'BigDecimal' },
-  upperTarget: { type: 'BigDecimal' },
+  mainIndex: { type: 'Int', static: true },
+  wrappedIndex: { type: 'Int', static: true },
+  lowerTarget: { type: 'BigDecimal', static: true },
+  upperTarget: { type: 'BigDecimal', static: true },
 };
+
+/**
+ * Used for marshalling / unmarshalling Pool Tokens for 
+ * DynamoDB. Also used for removing static items to save
+ * update bandwidth. 
+ */
+export const POOL_TOKEN_SCHEMA: Schema = {
+  name: { type: 'String', static: true },
+  symbol: { type: 'String', static: true },
+  address: { type: 'String', static: true },
+  decimals: { type: 'Int', static: true },
+  isExemptFromYieldProtocolFee: { type: 'Boolean', static: false },
+  weight: { type: 'BigDecimal', static: false },
+  price: { type: 'Object', static: false },
+  priceRate: { type: 'BigDecimal', static: false },
+  balance: { type: 'BigDecimal', static: false },
+  token: { type: 'BigDecimal', static: true }, // set to static so updatePools doesn't change it
+}

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -72,7 +72,6 @@ export const POOL_SCHEMA: Schema = {
 
   tokens: { type: 'Object', static: false},
   tokensList: { type: 'Array', static: false },
-  tokenAddresses: { type: 'Array', static: false },
 
   principalToken: { type: 'String', static: true },
   baseToken: { type: 'String', static: true },

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -73,9 +73,6 @@ export const POOL_SCHEMA: Schema = {
   tokens: { type: 'Object', static: false},
   tokensList: { type: 'Array', static: false },
 
-  principalToken: { type: 'String', static: true },
-  baseToken: { type: 'String', static: true },
-
   swapEnabled: { type: 'Boolean', static: false },
   swapFee: { type: 'BigDecimal', static: false },
 
@@ -95,10 +92,6 @@ export const POOL_SCHEMA: Schema = {
 
   // StablePool Only
   amp: { type: 'BigInt', static: false },
-
-  // ConvergentCurvePool (Element) Only
-  expiryTime: { type: 'BigInt', static: true },
-  unitSeconds: { type: 'BigInt', static: true },
 
   //InvestmentPool Only
   managementFee: { type: 'BigDecimal', static: false },

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -2,7 +2,7 @@ export const COINGECKO_BASEURL = 'https://api.coingecko.com/api/v3';
 export const COINGECKO_MAX_TOKENS_PER_PAGE = 100;
 export const COINGECKO_MAX_TPS = 10;
 
-export const MAX_BATCH_WRITE_SIZE = 25;
+export const MAX_BATCH_WRITE_SIZE = 20;
 export const MAX_DYNAMODB_PRECISION = 38;
 
 export const HOUR_IN_MS = 60 * 60 * 1000;

--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -75,9 +75,8 @@ export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
     poolUpdateRequestChunks.map(async (poolUpdateRequests) => {
       const params = {
         TransactItems: poolUpdateRequests,
-        ReturnConsumedCapacity: "TOTAL"
       };
-      const result = await dynamodb
+      await dynamodb
         .transactWriteItems(params, err => {
           if (err) {
             if (err.code === 'ProvisionedThroughputExceededException') {
@@ -94,7 +93,6 @@ export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
           }
         })
         .promise();
-      console.log(`Update Batch Pools (${poolUpdateRequests.length} total) Consumed Capacity: `, result.ConsumedCapacity);
     })
   );
 }

--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -15,6 +15,10 @@ import debug from 'debug';
 
 const log = debug('balancer:dynamodb');
 
+export interface UpdatePoolOptions {
+  ignoreStaticData: boolean; // Ignore fields that rarely ever change
+}
+
 function getDynamoDB() {
   const dynamoDBConfig = {
     maxRetries: 50,
@@ -45,7 +49,7 @@ export async function isAlive() {
   return true;
 }
 
-export async function updatePools(pools: Pool[]) {
+export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
   const dynamodb = getDynamoDB();
 
   const allPoolUpdateRequests = pools.map(function (pool) {
@@ -58,7 +62,7 @@ export async function updatePools(pools: Pool[]) {
           },
           TableName: 'pools',
         },
-        generateUpdateExpression(pool)
+        generateUpdateExpression(pool, options)
       ),
     };
   });
@@ -68,11 +72,12 @@ export async function updatePools(pools: Pool[]) {
     MAX_BATCH_WRITE_SIZE
   );
   return Promise.all(
-    poolUpdateRequestChunks.map(poolUpdateRequests => {
+    poolUpdateRequestChunks.map(async (poolUpdateRequests) => {
       const params = {
         TransactItems: poolUpdateRequests,
+        ReturnConsumedCapacity: "TOTAL"
       };
-      return dynamodb
+      const result = await dynamodb
         .transactWriteItems(params, err => {
           if (err) {
             if (err.code === 'ProvisionedThroughputExceededException') {
@@ -89,6 +94,7 @@ export async function updatePools(pools: Pool[]) {
           }
         })
         .promise();
+      console.log(`Update Batch Pools (${poolUpdateRequests.length} total) Consumed Capacity: `, result.ConsumedCapacity);
     })
   );
 }

--- a/src/lambdas/decorate-pools.ts
+++ b/src/lambdas/decorate-pools.ts
@@ -26,7 +26,7 @@ export const handler = async (): Promise<any> => {
       pool => pool.lastUpdate >= decorateStartTime
     );
     log(`Saving ${modifiedPools.length} modified pools to the database`);
-    await updatePools(modifiedPools);
+    await updatePools(modifiedPools, {ignoreStaticData: true});
     log(`Saved decorated pools for chain ${chainId}`);
     return { statusCode: 201, body: '' };
   } catch (err) {

--- a/src/lambdas/update-pools.ts
+++ b/src/lambdas/update-pools.ts
@@ -1,5 +1,5 @@
-import { getTokenAddressesFromPools } from '../utils';
-import { updatePools, updateTokens } from '../data-providers/dynamodb';
+import { getChangedPools, getTokenAddressesFromPools } from '../utils';
+import { getPools, updatePools, updateTokens } from '../data-providers/dynamodb';
 import {
   fetchPoolsFromChain,
   fetchTokens,
@@ -19,10 +19,12 @@ export const handler = async (): Promise<any> => {
     const poolsFromChain = await fetchPoolsFromChain(chainId);
     log(`Sanitizing ${poolsFromChain.length} pools`);
     const pools = sanitizePools(poolsFromChain);
-    log(`Saving ${pools.length} pools for chain ${chainId} to database`);
-    await updatePools(pools);
+    const currentPools = await getPools(chainId);
+    const changedPools = getChangedPools(pools, currentPools);
+    log(`Saving ${changedPools.length} pools for chain ${chainId} to database`);
+    await updatePools(changedPools);
     log(`Saved pools. Fetching Tokens for pools`);
-    const tokenAddresses = getTokenAddressesFromPools(pools);
+    const tokenAddresses = getTokenAddressesFromPools(changedPools);
     log(
       `Found ${tokenAddresses.length} tokens in pools on chain ${chainId}. Filtering by known tokens`
     );
@@ -34,7 +36,8 @@ export const handler = async (): Promise<any> => {
       `Fetching ${filteredTokenAddresses.length} tokens for chain ${chainId}`
     );
     const tokens = await fetchTokens(chainId, filteredTokenAddresses);
-    await updateTokens(tokens);
+    const tokenUpdateResult = await updateTokens(tokens);
+    log(`Token update result: ${tokenUpdateResult}`);
     log(`Saved ${filteredTokenAddresses.length} Tokens`);
     return { statusCode: 201, body: '' };
   } catch (dbError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,14 +54,15 @@ export interface SorRequest {
 
 export interface Schema {
   [key: string]: {
-    type: 'BigDecimal' | 'BigInt' | 'Boolean' | 'Int' | 'String';
+    type: 'BigDecimal' | 'BigInt' | 'Boolean' | 'Int' | 'String' | 'Object' | 'Array';
+    static: boolean;
   };
 }
 
 export interface UpdateExpression {
   UpdateExpression: string;
   ExpressionAttributeNames: { [key: string]: string };
-  ExpressionAttributeValues: { [key: string]: string };
+  ExpressionAttributeValues: { [key: string]: any };
 }
 export interface TRMAccountDetails {
   accountExternalId: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,6 @@ export interface Pool extends SDKPool {
     totalLiquidity?: string;
   };
   lastUpdate?: number;
-  principalToken?: string;
-  baseToken?: string;
-  expiryTime?: number;
-  unitSeconds?: number;
   managementFee?: string;
   mainIndex?: number;
   wrappedIndex?: number;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,6 @@
 import { AprBreakdown, Price } from '@balancer-labs/sdk';
-import { formatPrice, isValidApr } from './utils';
+import { formatPrice, getNonStaticSchemaFields, isValidApr } from './utils';
+import { Schema } from './types';
 
 describe('utils', () => {
   describe('isValidApr', () => {
@@ -121,5 +122,20 @@ describe('utils', () => {
       const formattedPrice = formatPrice(price);
       expect(formattedPrice).toEqual(expectedPrice);
     });
+  });
+
+  describe('getNonStaticSchemaFields', () => {
+    it('Should return a list of all schema fields that are static', () => {
+      const SCHEMA: Schema = {
+        id: { type: 'String', static: true},
+        totalSwapVolume: { type: 'BigDecimal', static: false },
+        createTime: { type: 'Int', static: true },
+        swapsCount: { type: 'BigInt', static: false},
+      };
+
+      const nonStaticFields = getNonStaticSchemaFields(SCHEMA);
+      const expectedFields = ['totalSwapVolume', 'swapsCount'];
+      expect(nonStaticFields).toEqual(expectedFields);
+    }); 
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,10 +236,7 @@ export function getChangedPools(newPools: Pool[], currentPools: Pool[]) {
   }));
 
   return newPools.filter((pool) => {
-    if (isSame(pool, currentPoolsMap[pool.id])) {
-      return false;
-    }
-    return true;
+    return !isSame(pool, currentPoolsMap[pool.id]); 
   });
 }
 
@@ -253,7 +250,7 @@ export function getNonStaticSchemaFields(schema: Schema): string[] {
   return compact(nonStaticFields);
 }
 
-export function isSame(newPool: Pool, oldPool: Pool): boolean {
+export function isSame(newPool: Pool, oldPool?: Pool): boolean {
   if (!oldPool) return false;
 
   const poolFieldsToCompare = getNonStaticSchemaFields(POOL_SCHEMA);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,12 +8,16 @@ import {
   SwapTypes,
 } from '@balancer-labs/sdk';
 import { getToken } from './data-providers/dynamodb';
-import { Token, Pool } from './types';
+import { Token, Pool, Schema } from './types';
 import {
   Network,
   NativeAssetAddress,
   NativeAssetPriceSymbol,
+  POOL_SCHEMA,
+  POOL_TOKEN_SCHEMA,
 } from './constants';
+import { isEqual, compact, pick } from 'lodash';
+import { inspect } from 'util';
 
 const { INFURA_PROJECT_ID } = process.env;
 
@@ -218,4 +222,55 @@ export function formatPrice(price: Price): Price {
   });
 
   return formattedPrice;
+}
+
+
+/** 
+ * Takes a list of currentPools and newPools and returns a list
+ * of all pools that have changed in newPools
+ */
+
+export function getChangedPools(newPools: Pool[], currentPools: Pool[]) {
+  const currentPoolsMap = Object.fromEntries(currentPools.map((pool)=> {
+    return [pool.id, pool];
+  }));
+
+  return newPools.filter((pool) => {
+    if (isSame(pool, currentPoolsMap[pool.id])) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function getNonStaticSchemaFields(schema: Schema): string[] {
+  const nonStaticFields = Object.entries(schema).map(([name, details]) => {
+    if (details.static) {
+      return null;
+    }
+    return name;
+  });
+  return compact(nonStaticFields);
+}
+
+export function isSame(newPool: Pool, oldPool: Pool): boolean {
+  if (!oldPool) return false;
+
+  const poolFieldsToCompare = getNonStaticSchemaFields(POOL_SCHEMA);
+  const tokenFieldsToCompare = getNonStaticSchemaFields(POOL_TOKEN_SCHEMA);
+  
+  const filteredOldPool = pick(oldPool, poolFieldsToCompare) ;
+  filteredOldPool.tokens = pick(oldPool.tokens, tokenFieldsToCompare);
+  const filteredNewPool = pick(newPool, poolFieldsToCompare);
+  filteredNewPool.tokens = pick(newPool.tokens, tokenFieldsToCompare);
+
+  const newPoolFields = Object.keys(filteredNewPool);
+
+  for (const key of newPoolFields) {
+    if (!isEqual(filteredNewPool[key], filteredOldPool[key])) {
+      console.log(`Updating pool ${newPool.id} -  ${key} is not equal. New: ${inspect(filteredNewPool[key], false, null)} Old: ${inspect(filteredOldPool[key], false, null)}`)
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
- In update pools compare all changeable pool fields to what they were previously and only update the pool if some have changed.
- Add list of static schema fields that shouldn't be updated because they never change.
- In Decorate Pools don't update these static fields.