### PR TITLE
Add SubPool Schema, PriceRateProviders

### DIFF
--- a/appsync/pools/schema.graphql
+++ b/appsync/pools/schema.graphql
@@ -30,6 +30,8 @@
 	upperTarget: String
 	apr: AprBreakdown
 	isNew: Boolean
+	protocolYieldFeeCache: String
+	priceRateProviders: [PriceRateProvider]
 }
 
 type PoolConnection {
@@ -45,8 +47,31 @@ type PoolToken @entity {
 	address: String
 	priceRate: String
 	balance: String
-	# WeightedPool Only
 	weight: String
+	token: SubPoolMeta
+}
+
+type SubPoolMeta @entity {
+	pool: SubPool
+	latestUSDPrice: String
+}
+
+type SubPool @entity {
+	id: String
+	address: String
+	poolType: String
+	totalShares: String
+	mainIndex: Int
+	tokens: [PoolToken]
+}
+
+type PriceRateProvider @entity {
+	address: String
+	token: PriceRateProviderToken
+}
+
+type PriceRateProviderToken @entity {
+	address: String
 }
 
 type AprBreakdown @entity {

--- a/index.ts
+++ b/index.ts
@@ -184,7 +184,7 @@ export class BalancerPoolsAPI extends Stack {
           entry: join(__dirname, 'src', 'lambdas', 'update-pools.ts'),
           ...functionProps,
           memorySize: 2048,
-          timeout: Duration.seconds(60),
+          timeout: Duration.seconds(300),
           reservedConcurrentExecutions: 1,
         }
       );
@@ -204,7 +204,7 @@ export class BalancerPoolsAPI extends Stack {
           entry: join(__dirname, 'src', 'lambdas', 'decorate-pools.ts'),
           ...functionProps,
           memorySize: 2048,
-          timeout: Duration.seconds(60),
+          timeout: Duration.seconds(300),
           reservedConcurrentExecutions: 1,
         }
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^0.1.37",
+        "@balancer-labs/sdk": "^0.1.39-beta.13",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "aws-cdk-lib": "^2.32.1",
@@ -652,11 +652,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.37.tgz",
-      "integrity": "sha512-O/0mz38ieyIvGaJfOfJrv3p/33EnAzHzLYtQN8iccUm9U1lHaIopS+2tfsAsTOjpkr8CQEgkMJEWO4fx2ywM9Q==",
+      "version": "0.1.39-beta.13",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.13.tgz",
+      "integrity": "sha512-qWMUC4kBvkM5ne6bpUkxeKFCFr4XBRojgF+Ou8niEujaZNRHI2Dp+n4h4TJUcRD3WEMMs3v4twAmoIBOJDwf3A==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.0.1-beta.12",
+        "@balancer-labs/sor": "^4.0.1-beta.14",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@balancer-labs/sor": {
-      "version": "4.0.1-beta.12",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.12.tgz",
-      "integrity": "sha512-RTb3cf/iPr/4HTMDvnArnwSp6p0Mx7B9J9O5h1+DPaC0VrFJani4T9x39J4v7RdAxtF39vnFpZ5uoVL8Sc28TQ==",
+      "version": "4.0.1-beta.14",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.14.tgz",
+      "integrity": "sha512-uT7pM4yfrWGpGZyWp3hac5uLGpmfYOfs5mV/tu+MDAgAEa4kVM+ra3fnIoHc8W09ijxFZHcfyalNB9LsoHH7IQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1"
       },
@@ -8778,11 +8778,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.37.tgz",
-      "integrity": "sha512-O/0mz38ieyIvGaJfOfJrv3p/33EnAzHzLYtQN8iccUm9U1lHaIopS+2tfsAsTOjpkr8CQEgkMJEWO4fx2ywM9Q==",
+      "version": "0.1.39-beta.13",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.39-beta.13.tgz",
+      "integrity": "sha512-qWMUC4kBvkM5ne6bpUkxeKFCFr4XBRojgF+Ou8niEujaZNRHI2Dp+n4h4TJUcRD3WEMMs3v4twAmoIBOJDwf3A==",
       "requires": {
-        "@balancer-labs/sor": "^4.0.1-beta.12",
+        "@balancer-labs/sor": "^4.0.1-beta.14",
         "@balancer-labs/typechain": "^1.0.0",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
@@ -8792,9 +8792,9 @@
       }
     },
     "@balancer-labs/sor": {
-      "version": "4.0.1-beta.12",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.12.tgz",
-      "integrity": "sha512-RTb3cf/iPr/4HTMDvnArnwSp6p0Mx7B9J9O5h1+DPaC0VrFJani4T9x39J4v7RdAxtF39vnFpZ5uoVL8Sc28TQ==",
+      "version": "4.0.1-beta.14",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.14.tgz",
+      "integrity": "sha512-uT7pM4yfrWGpGZyWp3hac5uLGpmfYOfs5mV/tu+MDAgAEa4kVM+ra3fnIoHc8W09ijxFZHcfyalNB9LsoHH7IQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^0.1.37",
+    "@balancer-labs/sdk": "^0.1.39-beta.13",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "aws-cdk-lib": "^2.32.1",

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -70,7 +70,7 @@ export const POOL_SCHEMA: Schema = {
 
   isNew: { type: 'Boolean', static: false},
 
-  tokens: { type: 'Object', static: false},
+  tokens: { type: 'Array', static: false},
   tokensList: { type: 'Array', static: false },
 
   swapEnabled: { type: 'Boolean', static: false },

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -57,34 +57,74 @@ export const TOKENS_TABLE_SCHEMA = {
  * BigNumber: Saved as a number in DynamoDB, but a String in JS
  */
 export const POOL_SCHEMA: Schema = {
-  swapEnabled: { type: 'Boolean' },
-  swapFee: { type: 'BigDecimal' },
+  id: { type: 'String', static: true },
+  chainId: { type: 'Int', static: true },
+  poolType: { type: 'String', static: true },
+  poolTypeVersion: { type: 'Int', static: true },
 
-  totalWeight: { type: 'BigDecimal' },
-  totalSwapVolume: { type: 'BigDecimal' },
-  totalSwapFee: { type: 'BigDecimal' },
-  totalLiquidity: { type: 'BigDecimal' },
-  totalShares: { type: 'BigDecimal' },
+  name: { type: 'String', static: false },
+  address: { type: 'String', static: true },
+  owner: { type: 'String', static: false },
+  factory: { type: 'String', static: true },
+  symbol: { type: 'String', static: true },
 
-  volumeSnapshot: { type: 'BigDecimal' },
+  isNew: { type: 'Boolean', static: false},
 
-  createTime: { type: 'Int' },
-  swapsCount: { type: 'BigInt' },
-  holdersCount: { type: 'BigInt' },
+  tokens: { type: 'Object', static: false},
+  tokensList: { type: 'Array', static: false },
+  tokenAddresses: { type: 'Array', static: false },
+
+  principalToken: { type: 'String', static: true },
+  baseToken: { type: 'String', static: true },
+
+  swapEnabled: { type: 'Boolean', static: false },
+  swapFee: { type: 'BigDecimal', static: false },
+
+  protocolYieldFeeCache: { type: 'String', static: false},
+
+  totalWeight: { type: 'BigDecimal', static: true },
+  totalSwapVolume: { type: 'BigDecimal', static: false },
+  totalSwapFee: { type: 'BigDecimal', static: false },
+  totalLiquidity: { type: 'BigDecimal', static: false },
+  totalShares: { type: 'BigDecimal', static: false },
+
+  volumeSnapshot: { type: 'BigDecimal', static: false },
+
+  createTime: { type: 'Int', static: true },
+  swapsCount: { type: 'BigInt', static: false },
+  holdersCount: { type: 'BigInt', static: false },
 
   // StablePool Only
-  amp: { type: 'BigInt' },
+  amp: { type: 'BigInt', static: false },
 
   // ConvergentCurvePool (Element) Only
-  expiryTime: { type: 'BigInt' },
-  unitSeconds: { type: 'BigInt' },
+  expiryTime: { type: 'BigInt', static: true },
+  unitSeconds: { type: 'BigInt', static: true },
 
   //InvestmentPool Only
-  managementFee: { type: 'BigDecimal' },
+  managementFee: { type: 'BigDecimal', static: false },
 
   // LinearPool only
-  mainIndex: { type: 'Int' },
-  wrappedIndex: { type: 'Int' },
-  lowerTarget: { type: 'BigDecimal' },
-  upperTarget: { type: 'BigDecimal' },
+  mainIndex: { type: 'Int', static: true },
+  wrappedIndex: { type: 'Int', static: true },
+  lowerTarget: { type: 'BigDecimal', static: true },
+  upperTarget: { type: 'BigDecimal', static: true },
 };
+
+/**
+ * Used for marshalling / unmarshalling Pool Tokens for 
+ * DynamoDB. Also used for removing static items to save
+ * update bandwidth. 
+ */
+export const POOL_TOKEN_SCHEMA: Schema = {
+  name: { type: 'String', static: true },
+  symbol: { type: 'String', static: true },
+  address: { type: 'String', static: true },
+  decimals: { type: 'Int', static: true },
+  isExemptFromYieldProtocolFee: { type: 'Boolean', static: false },
+  weight: { type: 'BigDecimal', static: false },
+  price: { type: 'Object', static: false },
+  priceRate: { type: 'BigDecimal', static: false },
+  balance: { type: 'BigDecimal', static: false },
+  token: { type: 'BigDecimal', static: true }, // set to static so updatePools doesn't change it
+}

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -72,7 +72,6 @@ export const POOL_SCHEMA: Schema = {
 
   tokens: { type: 'Object', static: false},
   tokensList: { type: 'Array', static: false },
-  tokenAddresses: { type: 'Array', static: false },
 
   principalToken: { type: 'String', static: true },
   baseToken: { type: 'String', static: true },

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -73,9 +73,6 @@ export const POOL_SCHEMA: Schema = {
   tokens: { type: 'Object', static: false},
   tokensList: { type: 'Array', static: false },
 
-  principalToken: { type: 'String', static: true },
-  baseToken: { type: 'String', static: true },
-
   swapEnabled: { type: 'Boolean', static: false },
   swapFee: { type: 'BigDecimal', static: false },
 
@@ -95,10 +92,6 @@ export const POOL_SCHEMA: Schema = {
 
   // StablePool Only
   amp: { type: 'BigInt', static: false },
-
-  // ConvergentCurvePool (Element) Only
-  expiryTime: { type: 'BigInt', static: true },
-  unitSeconds: { type: 'BigInt', static: true },
 
   //InvestmentPool Only
   managementFee: { type: 'BigDecimal', static: false },

--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -2,7 +2,7 @@ export const COINGECKO_BASEURL = 'https://api.coingecko.com/api/v3';
 export const COINGECKO_MAX_TOKENS_PER_PAGE = 100;
 export const COINGECKO_MAX_TPS = 10;
 
-export const MAX_BATCH_WRITE_SIZE = 25;
+export const MAX_BATCH_WRITE_SIZE = 20;
 export const MAX_DYNAMODB_PRECISION = 38;
 
 export const HOUR_IN_MS = 60 * 60 * 1000;

--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -75,9 +75,8 @@ export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
     poolUpdateRequestChunks.map(async (poolUpdateRequests) => {
       const params = {
         TransactItems: poolUpdateRequests,
-        ReturnConsumedCapacity: "TOTAL"
       };
-      const result = await dynamodb
+      await dynamodb
         .transactWriteItems(params, err => {
           if (err) {
             if (err.code === 'ProvisionedThroughputExceededException') {
@@ -94,7 +93,6 @@ export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
           }
         })
         .promise();
-      console.log(`Update Batch Pools (${poolUpdateRequests.length} total) Consumed Capacity: `, result.ConsumedCapacity);
     })
   );
 }

--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -15,6 +15,10 @@ import debug from 'debug';
 
 const log = debug('balancer:dynamodb');
 
+export interface UpdatePoolOptions {
+  ignoreStaticData: boolean; // Ignore fields that rarely ever change
+}
+
 function getDynamoDB() {
   const dynamoDBConfig = {
     maxRetries: 50,
@@ -45,7 +49,7 @@ export async function isAlive() {
   return true;
 }
 
-export async function updatePools(pools: Pool[]) {
+export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
   const dynamodb = getDynamoDB();
 
   const allPoolUpdateRequests = pools.map(function (pool) {
@@ -58,7 +62,7 @@ export async function updatePools(pools: Pool[]) {
           },
           TableName: 'pools',
         },
-        generateUpdateExpression(pool)
+        generateUpdateExpression(pool, options)
       ),
     };
   });
@@ -68,11 +72,12 @@ export async function updatePools(pools: Pool[]) {
     MAX_BATCH_WRITE_SIZE
   );
   return Promise.all(
-    poolUpdateRequestChunks.map(poolUpdateRequests => {
+    poolUpdateRequestChunks.map(async (poolUpdateRequests) => {
       const params = {
         TransactItems: poolUpdateRequests,
+        ReturnConsumedCapacity: "TOTAL"
       };
-      return dynamodb
+      const result = await dynamodb
         .transactWriteItems(params, err => {
           if (err) {
             if (err.code === 'ProvisionedThroughputExceededException') {
@@ -89,6 +94,7 @@ export async function updatePools(pools: Pool[]) {
           }
         })
         .promise();
+      console.log(`Update Batch Pools (${poolUpdateRequests.length} total) Consumed Capacity: `, result.ConsumedCapacity);
     })
   );
 }

--- a/src/lambdas/decorate-pools.ts
+++ b/src/lambdas/decorate-pools.ts
@@ -26,7 +26,7 @@ export const handler = async (): Promise<any> => {
       pool => pool.lastUpdate >= decorateStartTime
     );
     log(`Saving ${modifiedPools.length} modified pools to the database`);
-    await updatePools(modifiedPools);
+    await updatePools(modifiedPools, {ignoreStaticData: true});
     log(`Saved decorated pools for chain ${chainId}`);
     return { statusCode: 201, body: '' };
   } catch (err) {

--- a/src/lambdas/decorate-pools.ts
+++ b/src/lambdas/decorate-pools.ts
@@ -19,7 +19,7 @@ export const handler = async (): Promise<any> => {
     const pools = await getPools(chainId);
     log(`Decoracting ${pools.length} pools for chain ${chainId}`);
     const decorateStartTime = Date.now();
-    const poolDecorator = new PoolDecorator(pools, chainId);
+    const poolDecorator = new PoolDecorator(pools, { chainId });
     const decoratedPools = await poolDecorator.decorate(tokens);
     log(`Decorated ${decoratedPools.length} pools`);
     const modifiedPools = decoratedPools.filter(

--- a/src/lambdas/update-pools.ts
+++ b/src/lambdas/update-pools.ts
@@ -1,5 +1,5 @@
-import { getTokenAddressesFromPools } from '../utils';
-import { updatePools, updateTokens } from '../data-providers/dynamodb';
+import { getChangedPools, getTokenAddressesFromPools } from '../utils';
+import { getPools, updatePools, updateTokens } from '../data-providers/dynamodb';
 import {
   fetchPoolsFromChain,
   fetchTokens,
@@ -19,10 +19,12 @@ export const handler = async (): Promise<any> => {
     const poolsFromChain = await fetchPoolsFromChain(chainId);
     log(`Sanitizing ${poolsFromChain.length} pools`);
     const pools = sanitizePools(poolsFromChain);
-    log(`Saving ${pools.length} pools for chain ${chainId} to database`);
-    await updatePools(pools);
+    const currentPools = await getPools(chainId);
+    const changedPools = getChangedPools(pools, currentPools);
+    log(`Saving ${changedPools.length} pools for chain ${chainId} to database`);
+    await updatePools(changedPools);
     log(`Saved pools. Fetching Tokens for pools`);
-    const tokenAddresses = getTokenAddressesFromPools(pools);
+    const tokenAddresses = getTokenAddressesFromPools(changedPools);
     log(
       `Found ${tokenAddresses.length} tokens in pools on chain ${chainId}. Filtering by known tokens`
     );
@@ -34,7 +36,8 @@ export const handler = async (): Promise<any> => {
       `Fetching ${filteredTokenAddresses.length} tokens for chain ${chainId}`
     );
     const tokens = await fetchTokens(chainId, filteredTokenAddresses);
-    await updateTokens(tokens);
+    const tokenUpdateResult = await updateTokens(tokens);
+    log(`Token update result: ${tokenUpdateResult}`);
     log(`Saved ${filteredTokenAddresses.length} Tokens`);
     return { statusCode: 201, body: '' };
   } catch (dbError) {

--- a/src/pools/pool.decorator.ts
+++ b/src/pools/pool.decorator.ts
@@ -7,6 +7,7 @@ import {
   StaticTokenProvider,
   BalancerSdkConfig,
   BalancerSDK,
+  BalancerNetworkConfig,
   PoolType,
 } from '@balancer-labs/sdk';
 import { tokensToTokenPrices } from '../tokens';
@@ -19,8 +20,16 @@ const log = debug('balancer:pool-decorator');
 
 const IGNORED_POOL_TYPES = [PoolType.Element, PoolType.Gyro2, PoolType.Gyro3];
 
+export interface PoolDecoratorOptions {
+  chainId?: number;
+  poolsToDecorate?: Pool[];
+}
+
 export class PoolDecorator {
-  constructor(public pools: Pool[], private networkId: number = 1) {}
+  poolsRepositories: BalancerDataRepositories;
+  networkConfig: BalancerNetworkConfig;
+
+  constructor(public pools: Pool[], private options: PoolDecoratorOptions = {}) {}
 
   public async decorate(tokens: Token[]): Promise<Pool[]> {
     log('------- START Decorating pools --------');
@@ -31,14 +40,20 @@ export class PoolDecorator {
     const tokenPriceProvider = new StaticTokenPriceProvider(tokenPrices);
     const tokenProvider = new StaticTokenProvider(tokens);
 
+    const chainId = this.options.chainId || 1;
+
+    // poolsToDecorate will be a reference to this.pools, but I think this is ok as we want 
+    // the pools in the core list to be updated. Watch out for possible future oddities due to this though.
+    const poolsToDecorate = this.options.poolsToDecorate || this.pools;
+
     const balancerConfig: BalancerSdkConfig = {
-      network: this.networkId,
-      rpcUrl: getInfuraUrl(this.networkId),
+      network: chainId,
+      rpcUrl: getInfuraUrl(chainId),
     };
     const balancerSdk = new BalancerSDK(balancerConfig);
     const dataRepositories = balancerSdk.data;
 
-    const poolsRepositories: BalancerDataRepositories = {
+    this.poolsRepositories = {
       ...dataRepositories,
       ...{
         pools: poolProvider,
@@ -47,48 +62,59 @@ export class PoolDecorator {
       },
     };
 
-    const networkConfig = balancerSdk.networkConfig;
-
-    async function decoratePool(pool) {
-      if (IGNORED_POOL_TYPES.includes(pool.poolType)) return pool;
-
-      let poolService;
-      try {
-        poolService = new PoolService(pool, networkConfig, poolsRepositories);
-      } catch (e) {
-        console.log(
-          `Failed to initialize pool service. Error is: ${e}. Pool is:  ${util.inspect(
-            pool,
-            false,
-            null
-          )}`
-        );
-        return pool;
-      }
-
-      await poolService.setTotalLiquidity();
-      await poolService.setApr();
-      await poolService.setVolumeSnapshot();
-      poolService.setIsNew();
-
-      return poolService.pool;
-    }
+    this.networkConfig = balancerSdk.networkConfig;
 
     let processedPools = [];
     const batchSize = 10;
 
     log(`Processing ${this.pools.length} pools`);
 
-    for (let i = 0; i < this.pools.length; i += batchSize) {
-      log(`Processing pools ${i} -> ${i + batchSize}`);
+    for (let i = 0; i < poolsToDecorate.length; i += batchSize) {
+      log(`Decorating pools ${i} -> ${i + batchSize}`);
       const batch = await Promise.all(
-        this.pools.slice(i, i + batchSize).map(pool => decoratePool(pool))
+        poolsToDecorate.slice(i, i + batchSize).map(pool => this.decoratePool(pool))
       );
       processedPools = processedPools.concat(batch);
     }
-
+    
     log('------- END decorating pools --------');
 
     return processedPools;
+  }
+
+  private async decoratePool(pool) {
+    if (IGNORED_POOL_TYPES.includes(pool.poolType)) return pool;
+
+    let poolService;
+    try {
+      poolService = new PoolService(pool, this.networkConfig, this.poolsRepositories);
+    } catch (e) {
+      console.log(
+        `Failed to initialize pool service. Error is: ${e}. Pool is:  ${util.inspect(
+          pool,
+          false,
+          null
+        )}`
+      );
+      return pool;
+    }
+
+    try {
+      await Promise.all([
+        poolService.setTotalLiquidity(),
+        poolService.setApr(),
+        poolService.setVolumeSnapshot(),
+      ]);
+
+      poolService.setIsNew()
+    } catch (e) {
+      console.log(`Failed to decorate pool ${pool.id} Error is: ${e}. Pool is: ${util.inspect(
+        pool,
+        false,
+        null
+      )}`)
+    }
+
+    return poolService.pool;
   }
 }

--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -68,6 +68,7 @@ export class PoolService {
     }
 
     if (poolLiquidity !== this.pool.totalLiquidity) {
+      console.log(`Updated pool ${this.pool.id} to Liquidity: ${poolLiquidity}`);
       this.pool.lastUpdate = Date.now();
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,14 +54,15 @@ export interface SorRequest {
 
 export interface Schema {
   [key: string]: {
-    type: 'BigDecimal' | 'BigInt' | 'Boolean' | 'Int' | 'String';
+    type: 'BigDecimal' | 'BigInt' | 'Boolean' | 'Int' | 'String' | 'Object' | 'Array';
+    static: boolean;
   };
 }
 
 export interface UpdateExpression {
   UpdateExpression: string;
   ExpressionAttributeNames: { [key: string]: string };
-  ExpressionAttributeValues: { [key: string]: string };
+  ExpressionAttributeValues: { [key: string]: any };
 }
 export interface TRMAccountDetails {
   accountExternalId: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,8 +36,6 @@ export interface Pool extends SDKPool {
   managementFee?: string;
   mainIndex?: number;
   wrappedIndex?: number;
-  lowerTarget?: string;
-  upperTarget?: string;
 }
 
 export interface SorRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,6 @@ export interface Pool extends SDKPool {
     totalLiquidity?: string;
   };
   lastUpdate?: number;
-  principalToken?: string;
-  baseToken?: string;
-  expiryTime?: number;
-  unitSeconds?: number;
   managementFee?: string;
   mainIndex?: number;
   wrappedIndex?: number;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,6 @@
 import { AprBreakdown, Price } from '@balancer-labs/sdk';
-import { formatPrice, isValidApr } from './utils';
+import { formatPrice, getNonStaticSchemaFields, isValidApr } from './utils';
+import { Schema } from './types';
 
 describe('utils', () => {
   describe('isValidApr', () => {
@@ -121,5 +122,20 @@ describe('utils', () => {
       const formattedPrice = formatPrice(price);
       expect(formattedPrice).toEqual(expectedPrice);
     });
+  });
+
+  describe('getNonStaticSchemaFields', () => {
+    it('Should return a list of all schema fields that are static', () => {
+      const SCHEMA: Schema = {
+        id: { type: 'String', static: true},
+        totalSwapVolume: { type: 'BigDecimal', static: false },
+        createTime: { type: 'Int', static: true },
+        swapsCount: { type: 'BigInt', static: false},
+      };
+
+      const nonStaticFields = getNonStaticSchemaFields(SCHEMA);
+      const expectedFields = ['totalSwapVolume', 'swapsCount'];
+      expect(nonStaticFields).toEqual(expectedFields);
+    }); 
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,10 +236,7 @@ export function getChangedPools(newPools: Pool[], currentPools: Pool[]) {
   }));
 
   return newPools.filter((pool) => {
-    if (isSame(pool, currentPoolsMap[pool.id])) {
-      return false;
-    }
-    return true;
+    return !isSame(pool, currentPoolsMap[pool.id]); 
   });
 }
 
@@ -253,7 +250,7 @@ export function getNonStaticSchemaFields(schema: Schema): string[] {
   return compact(nonStaticFields);
 }
 
-export function isSame(newPool: Pool, oldPool: Pool): boolean {
+export function isSame(newPool: Pool, oldPool?: Pool): boolean {
   if (!oldPool) return false;
 
   const poolFieldsToCompare = getNonStaticSchemaFields(POOL_SCHEMA);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,12 +8,16 @@ import {
   SwapTypes,
 } from '@balancer-labs/sdk';
 import { getToken } from './data-providers/dynamodb';
-import { Token, Pool } from './types';
+import { Token, Pool, Schema } from './types';
 import {
   Network,
   NativeAssetAddress,
   NativeAssetPriceSymbol,
+  POOL_SCHEMA,
+  POOL_TOKEN_SCHEMA,
 } from './constants';
+import { isEqual, compact, pick } from 'lodash';
+import { inspect } from 'util';
 
 const { INFURA_PROJECT_ID } = process.env;
 
@@ -218,4 +222,55 @@ export function formatPrice(price: Price): Price {
   });
 
   return formattedPrice;
+}
+
+
+/** 
+ * Takes a list of currentPools and newPools and returns a list
+ * of all pools that have changed in newPools
+ */
+
+export function getChangedPools(newPools: Pool[], currentPools: Pool[]) {
+  const currentPoolsMap = Object.fromEntries(currentPools.map((pool)=> {
+    return [pool.id, pool];
+  }));
+
+  return newPools.filter((pool) => {
+    if (isSame(pool, currentPoolsMap[pool.id])) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function getNonStaticSchemaFields(schema: Schema): string[] {
+  const nonStaticFields = Object.entries(schema).map(([name, details]) => {
+    if (details.static) {
+      return null;
+    }
+    return name;
+  });
+  return compact(nonStaticFields);
+}
+
+export function isSame(newPool: Pool, oldPool: Pool): boolean {
+  if (!oldPool) return false;
+
+  const poolFieldsToCompare = getNonStaticSchemaFields(POOL_SCHEMA);
+  const tokenFieldsToCompare = getNonStaticSchemaFields(POOL_TOKEN_SCHEMA);
+  
+  const filteredOldPool = pick(oldPool, poolFieldsToCompare) ;
+  filteredOldPool.tokens = pick(oldPool.tokens, tokenFieldsToCompare);
+  const filteredNewPool = pick(newPool, poolFieldsToCompare);
+  filteredNewPool.tokens = pick(newPool.tokens, tokenFieldsToCompare);
+
+  const newPoolFields = Object.keys(filteredNewPool);
+
+  for (const key of newPoolFields) {
+    if (!isEqual(filteredNewPool[key], filteredOldPool[key])) {
+      console.log(`Updating pool ${newPool.id} -  ${key} is not equal. New: ${inspect(filteredNewPool[key], false, null)} Old: ${inspect(filteredOldPool[key], false, null)}`)
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
- Add SubPool schema to GraphQL so subpools can now be fetched. These subpools are automatically pulled via the SDK in pool updates
- Add priceRateProvider's for pools
- Refactor PoolDecorator so that it can be used with only a subset of pools instead of having to decorate all each time.
- Use latest SDK
- Increase timeout of update and decorate lambdas as they were sometimes reaching their limits on Polygon. 