### PR TITLE
Fix Subpool Token Updating

### DIFF
--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -118,5 +118,5 @@ export const POOL_TOKEN_SCHEMA: Schema = {
   price: { type: 'Object', static: false },
   priceRate: { type: 'BigDecimal', static: false },
   balance: { type: 'BigDecimal', static: false },
-  token: { type: 'BigDecimal', static: true }, // set to static so updatePools doesn't change it
+  token: { type: 'BigDecimal', static: false }, 
 }

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -118,5 +118,5 @@ export const POOL_TOKEN_SCHEMA: Schema = {
   price: { type: 'Object', static: false },
   priceRate: { type: 'BigDecimal', static: false },
   balance: { type: 'BigDecimal', static: false },
-  token: { type: 'BigDecimal', static: false }, 
+  token: { type: 'Object', static: false }, 
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,6 +1,11 @@
 import { AprBreakdown, Price } from '@balancer-labs/sdk';
-import { formatPrice, getNonStaticSchemaFields, isValidApr } from './utils';
-import { Schema } from './types';
+import { formatPrice, getNonStaticSchemaFields, isSame, isValidApr } from './utils';
+import { Pool, Schema } from './types';
+import _ from 'lodash';
+
+import POOLS from '../test/mocks/pools';
+
+jest.unmock('@balancer-labs/sdk');
 
 describe('utils', () => {
   describe('isValidApr', () => {
@@ -124,8 +129,37 @@ describe('utils', () => {
     });
   });
 
+  describe('isSame', () => {
+    let newPool: Pool;
+    let oldPool: Pool | undefined;
+
+    beforeEach(() => {
+      newPool = POOLS[0];
+    });
+
+    it('Should return false if oldPool is undefined', () => {
+      const same = isSame(newPool);
+      expect(same).toBe(false);
+    })
+
+    it('Should return true if oldPool is the same', () => {
+      oldPool = Object.assign({}, POOLS[0]);
+      const same = isSame(newPool, oldPool);
+      expect(same).toBe(true);
+    });
+
+    it('Should return false if oldPool has slightly different tokens', () => {
+      oldPool = _.cloneDeep(POOLS[0]);
+      if (oldPool && oldPool.tokens) {
+        oldPool.tokens[0].balance = "12345";
+      }
+      const same = isSame(newPool, oldPool);
+      expect(same).toBe(false);
+    })
+  })
+
   describe('getNonStaticSchemaFields', () => {
-    it('Should return a list of all schema fields that are static', () => {
+    it('Should return a list of all schema fields that are not static', () => {
       const SCHEMA: Schema = {
         id: { type: 'String', static: true},
         totalSwapVolume: { type: 'BigDecimal', static: false },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -257,9 +257,9 @@ export function isSame(newPool: Pool, oldPool?: Pool): boolean {
   const tokenFieldsToCompare = getNonStaticSchemaFields(POOL_TOKEN_SCHEMA);
   
   const filteredOldPool = pick(oldPool, poolFieldsToCompare) ;
-  filteredOldPool.tokens = pick(oldPool.tokens, tokenFieldsToCompare);
+  filteredOldPool.tokens = oldPool.tokens.map((token) => pick(token, tokenFieldsToCompare));
   const filteredNewPool = pick(newPool, poolFieldsToCompare);
-  filteredNewPool.tokens = pick(newPool.tokens, tokenFieldsToCompare);
+  filteredNewPool.tokens = newPool.tokens.map((token) => pick(token, tokenFieldsToCompare));
 
   const newPoolFields = Object.keys(filteredNewPool);
 


### PR DESCRIPTION
I originally had this set to static because pool decoration was adding all the sub-pool information. Now that this information is coming from the sub-graph instead this field should be compared and the pool should be updated if it's different. 

Also fixes another bug that was uncovered where tokens weren't being compared correctly so pools weren't being updated when their token information changed. 