### PR TITLE
Add separate try/catch for pool and token updating

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,7 @@ export async function getTokenInfo(
   return tokenInfo;
 }
 
-export function getTokenAddressesFromPools(pools: Pool[]) {
+export function getTokenAddressesFromPools(pools: Pool[]): string[] {
   const tokenAddressMap = {};
   pools.forEach(pool => {
     pool.tokensList.forEach(address => {


### PR DESCRIPTION
In production there is one pool that is failing to update due to a validation error. I'm still debugging why it's happening but in the meanwhile this is causing tokens to not be updated correctly because when a pool fails to update the entire lambda ends. 

This changes the update lambda to have a separate try/catch for tokens so they can still be updated even if a pool fails. 

It also doesn't output the DB error so we don't accidentally leak information, as users shouldn't be calling this endpoint. 