### PR TITLE
Check for Infinity in APRs and don't allow saving it out if found

### DIFF
--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -107,7 +107,7 @@ export class PoolService {
     try {
       const apr = await this.pools.apr(this.pool);
       if (!isValidApr(apr)) {
-        throw new Error('APR is invalid - contains NaN');
+        throw new Error('APR is invalid - contains NaN or Infinity');
       }
       poolApr = apr;
     } catch (e) {

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -55,6 +55,29 @@ describe('utils', () => {
       expect(isValidApr(invalidStakingApr)).toBe(false);
     });
 
+    it('Should return false if the swap fees APR is Infinity', () => {
+      const invalidStakingApr: AprBreakdown = {
+        swapFees: Infinity,
+        tokenAprs: {
+          total: 0,
+          breakdown: {},
+        },
+        stakingApr: {
+          min: 0,
+          max: 0,
+        },
+        rewardAprs: {
+          total: 0,
+          breakdown: {},
+        },
+        protocolApr: 0,
+        min: 0,
+        max: 0,
+      };
+
+      expect(isValidApr(invalidStakingApr)).toBe(false);
+    });
+
     it('Should return true if the APR is the default empty APR', () => {
       const defaultApr: AprBreakdown = {
         swapFees: 0,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,8 +205,10 @@ export function isValidApr(apr: AprBreakdown) {
   for (const value of Object.values(apr)) {
     if (typeof value === 'object') {
       if (!isValidApr(value)) return false;
-    } else if (isNaN(value)) return false;
-    else if (!isFinite(value)) return false;
+    } else {
+      if (isNaN(value)) return false;
+      if (!isFinite(value)) return false;
+    }
   }
 
   return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -206,6 +206,7 @@ export function isValidApr(apr: AprBreakdown) {
     if (typeof value === 'object') {
       if (!isValidApr(value)) return false;
     } else if (isNaN(value)) return false;
+    else if (!isFinite(value)) return false;
   }
 
   return true;


### PR DESCRIPTION
There is one pool on Polygon that is somehow getting Infinity swap fees (assuming becuase liquidity is calculated as 0, I still need to investigate further why this is happening). DynamoDB doesn't allow saving Infinity and so the update fails on this pool. 

Adding this check so that if any APR values are Infinity the APR won't be updated. 