### PR TITLE
Increase token fetch timeout to 2m, add more logs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -267,8 +267,8 @@ export class BalancerPoolsAPI extends Stack {
      * Lambda Schedules
      */
 
-    const updateTokenPricesRule = new Rule(this, 'updateEachMinute', {
-      schedule: Schedule.expression('rate(1 minute)'),
+    const updateTokenPricesRule = new Rule(this, 'updateTokensInterval', {
+      schedule: Schedule.expression('rate(2 minutes)'),
     });
     updateTokenPricesRule.addTarget(
       new LambdaFunction(updateTokenPricesLambda)

--- a/src/price-fetcher.ts
+++ b/src/price-fetcher.ts
@@ -98,6 +98,7 @@ class PriceFetcher {
 
     let coinGeckoData;
     try {
+      console.log(`Fetching batch prices of size ${nextBatch.length} for chain ${nextChainId}`);
       coinGeckoData = await this.fetchPrices(nextChainId, nextBatch);
     } catch (err) {
       console.error('Got error: ', err, ' reading prices from coingecko.');
@@ -114,6 +115,8 @@ class PriceFetcher {
         this.queue = this.queue.concat(nextBatch);
       }
     }
+
+    console.log('Batch fetch complete.')
 
     nextBatch.forEach(token => {
       try {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -10,9 +10,9 @@ export async function updateTokenPrices(
   abortOnRateLimit = false
 ) {
   const priceFetcher = new PriceFetcher(abortOnRateLimit);
-  log(`fetching prics for ${tokens.length} tokens`);
+  log(`fetching prices for ${tokens.length} tokens`);
   const tokensWithPrices = await priceFetcher.fetch(tokens);
-  log('writing to DB');
+  log(`Saving ${tokensWithPrices.length} updated tokens to DB`);
   await updateTokens(tokensWithPrices);
   log('finished updating token prices');
 }


### PR DESCRIPTION
I noticed the token price fetch lambda was sometimes immediately giving 429 errors because Coingecko seems to expire their rate limit after a little over a minute. So changing it to 2 min ensures it always succeeds. 

Also added a few more logs to gain more insight into how many tokens are being updated each fetch. 