### PR TITLE
Integrate appsync with apigateway

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,13 +3,13 @@ import {
   DomainName,
   IResource,
   LambdaIntegration,
-  AwsIntegration,
   MockIntegration,
   PassthroughBehavior,
   RestApi,
   LogGroupLogDestination,
   AccessLogFormat,
   Model,
+  HttpIntegration,
 } from 'aws-cdk-lib/aws-apigateway';
 import { AttributeType, Table, ProjectionType } from 'aws-cdk-lib/aws-dynamodb';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -608,15 +608,10 @@ export class BalancerPoolsAPI extends Stack {
      * ApiGateway Appsync Path
      */
     const graphQLApiEndpoint = api.root.addResource('graphql');
-    graphQLApiEndpoint.addMethod('POST', new AwsIntegration({
-      service: 'appsync-api',
-      region: this.region,
-      subdomain: graphqlApi.apiId,
-      integrationHttpMethod: 'POST',
-      path: 'graphql',
+    graphQLApiEndpoint.addMethod('POST', new HttpIntegration(graphqlApi.graphqlUrl, {
+      proxy: true,
+      httpMethod: 'POST',
       options: {
-        passthroughBehavior: PassthroughBehavior.WHEN_NO_TEMPLATES,
-        credentialsRole: appSyncAccessRole,
         integrationResponses: [{
           statusCode: '200'
         }],

--- a/index.ts
+++ b/index.ts
@@ -341,23 +341,22 @@ export class BalancerPoolsAPI extends Stack {
       }
     });
 
-    // development stage
-    const devLogGroup = new LogGroup(this, "ApiGatewayDevLogs");
+    const apiGatewayLogGroup = new LogGroup(this, "ApiGatewayLogs");
     
     const api = new RestApi(this, 'poolsApi', {
       restApiName: 'Pools Service',
       deployOptions: {
-        accessLogDestination: new LogGroupLogDestination(devLogGroup),
+        accessLogDestination: new LogGroupLogDestination(apiGatewayLogGroup),
         accessLogFormat: AccessLogFormat.jsonWithStandardFields({
           caller: false,
           httpMethod: true,
-          ip: true,
+          ip: false,
           protocol: true,
           requestTime: true,
           resourcePath: true,
           responseLength: true,
           status: true,
-          user: true
+          user: false
         }),
         cachingEnabled: true,
         cacheClusterEnabled: true,

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,7 @@ import {
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
-import { Role, ServicePrincipal, ManagedPolicy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
+import { Role, ServicePrincipal, ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import {
   GraphqlApi,
   Schema,
@@ -587,22 +587,6 @@ export class BalancerPoolsAPI extends Stack {
         join(__dirname, 'appsync/pools/responseMapper.vtl')
       ),
     });
-
-    /** 
-     * ApiGateway -> Appsync IAM 
-     **/
-
-    const appSyncAccessPolicy = new PolicyStatement({
-        actions: ['appsync:GraphQL'],
-        resources: [`${graphqlApi.arn}/*`],
-        effect: Effect.ALLOW,
-    });
-
-    const appSyncAccessRole = new Role(this, 'appsync-access-role', {
-      assumedBy: new ServicePrincipal('apigateway.amazonaws.com')
-    });
-
-    appSyncAccessRole.addToPolicy(appSyncAccessPolicy);
 
     /**
      * ApiGateway Appsync Path


### PR DESCRIPTION
- Adds a /graphql endpoint to API Gateway that forwards to Appsync so that we can host the graphql endpoint at https://api.balancer.fi/graphql. 
- Automatically forwards the API Key for GraphQL via API Gateway so users don't have to pass it along and we don't have to expose it in the frontend. 
- Adds logs to API Gateway which were used for debugging but will also be useful for error reporting / diagnosis in the future. 


