### PR TITLE
Disable global API Gateway Caching, add caching for pools and tokens

### DIFF
--- a/src/lambdas/get-pool.ts
+++ b/src/lambdas/get-pool.ts
@@ -4,6 +4,7 @@ import {
   INVALID_CHAIN_ID_ERROR,
   MISSING_CHAIN_ID_ERROR,
 } from '../constants/errors';
+import { formatResponse } from './utils';
 
 export const handler = async (event: any = {}): Promise<any> => {
   const chainId = parseInt(event.pathParameters.chainId);
@@ -22,11 +23,11 @@ export const handler = async (event: any = {}): Promise<any> => {
   try {
     const pool = await getPool(chainId, poolId);
     if (pool) {
-      return { statusCode: 200, body: JSON.stringify(pool) };
+      return formatResponse(200, JSON.stringify(pool));
     } else {
-      return { statusCode: 404 };
+      return formatResponse(404, 'Cannot find pool')
     }
   } catch (dbError) {
-    return { statusCode: 500, body: JSON.stringify(dbError) };
+    return formatResponse(500, 'Internal DB Error');
   }
 };

--- a/src/lambdas/get-pool.ts
+++ b/src/lambdas/get-pool.ts
@@ -25,7 +25,7 @@ export const handler = async (event: any = {}): Promise<any> => {
     if (pool) {
       return formatResponse(200, JSON.stringify(pool));
     } else {
-      return formatResponse(404, 'Cannot find pool')
+      return formatResponse(404)
     }
   } catch (dbError) {
     return formatResponse(500, 'Internal DB Error');

--- a/src/lambdas/get-pools.ts
+++ b/src/lambdas/get-pools.ts
@@ -4,6 +4,7 @@ import {
   INVALID_CHAIN_ID_ERROR,
   MISSING_CHAIN_ID_ERROR,
 } from '../constants/errors';
+import { formatResponse } from './utils';
 
 export const handler = async (event: any = {}): Promise<any> => {
   const chainId = parseInt(event.pathParameters.chainId);
@@ -14,24 +15,10 @@ export const handler = async (event: any = {}): Promise<any> => {
     return INVALID_CHAIN_ID_ERROR;
   }
 
-  const corsHeaders = {
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'OPTIONS,GET',
-  };
-
   try {
     const pools = await getPools(chainId);
-    return {
-      statusCode: 200,
-      headers: corsHeaders,
-      body: JSON.stringify(pools),
-    };
+    return formatResponse(200, JSON.stringify(pools));
   } catch (dbError) {
-    return {
-      statusCode: 500,
-      headers: corsHeaders,
-      body: JSON.stringify(dbError),
-    };
+    return formatResponse(500, 'Internal DB Error');
   }
 };

--- a/src/lambdas/utils.ts
+++ b/src/lambdas/utils.ts
@@ -1,4 +1,4 @@
-export function formatResponse(statusCode: number, body: string) {
+export function formatResponse(statusCode: number, body?: string) {
   return {
     statusCode,
     headers: {

--- a/src/lambdas/utils.ts
+++ b/src/lambdas/utils.ts
@@ -5,7 +5,7 @@ export function formatResponse(statusCode: number, body: string) {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'OPTIONS,POST',
+      'Access-Control-Allow-Methods': 'OPTIONS,GET,POST',
     },
     body,
   };


### PR DESCRIPTION
API Gateway was caching all calls to pools/1/ID saving the same data even for different ID's / chains (the call was only cached once), which is not what we want. I was very confused by this in testing.This PR disables the cache on all routes by default and we have to manually enable it now to ensure that routes function as we expect. 

- Disables caching by default on all routes, only specified paths are cached now. 
- Add caching for pools/{chainId}, pools/{chainId}/{id} and tokens/{chainId}. With caching on individual path params. 30s cache for all of them.
- Add CORS headers to the get-pool function so it can be used by the frontend, and refactor a few lambdas to not expose DB error info and use common response functions. 