### PR TITLE
feat: Add Sentry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
         TENDERLY_USER: ${{ secrets.TENDERLY_USER }}
         TENDERLY_PROJECT: ${{ secrets.TENDERLY_PROJECT }}
         TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+        SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         DOMAIN_NAME: 'api.balancer.fi'
         NETWORKS: '1,137,42161'
         DYNAMODB_POOLS_READ_CAPACITY: 1500

--- a/index.ts
+++ b/index.ts
@@ -49,6 +49,7 @@ const {
   TENDERLY_USER,
   TENDERLY_PROJECT,
   TENDERLY_ACCESS_KEY,
+  SENTRY_DSN,
 } = process.env;
 
 let SELECTED_NETWORKS: Record<string, number> = PRODUCTION_NETWORKS;
@@ -155,6 +156,7 @@ export class BalancerPoolsAPI extends Stack {
       },
       environment: {
         INFURA_PROJECT_ID: INFURA_PROJECT_ID || '',
+        SENTRY_DSN: SENTRY_DSN || '',
       },
       runtime: Runtime.NODEJS_14_X,
       timeout: Duration.seconds(15),
@@ -321,7 +323,7 @@ export class BalancerPoolsAPI extends Stack {
     const getPoolIntegration = new LambdaIntegration(getPoolLambda, {
       proxy: true,
       cacheKeyParameters: ["method.request.path.chainId", "method.request.path.id"],
-      cacheNamespace: 'chainId-poolId',
+      cacheNamespace: 'getPool',
       requestParameters: {
         "integration.request.path.chainId": "method.request.path.chainId",
         "integration.request.path.id": "method.request.path.id"
@@ -330,7 +332,7 @@ export class BalancerPoolsAPI extends Stack {
     const getPoolsIntegration = new LambdaIntegration(getPoolsLambda, {
       proxy: true,
       cacheKeyParameters: ["method.request.path.chainId"],
-      cacheNamespace: 'chainId',
+      cacheNamespace: 'getPools',
       requestParameters: {
         "integration.request.path.chainId": "method.request.path.chainId"
       }
@@ -338,7 +340,7 @@ export class BalancerPoolsAPI extends Stack {
     const getTokensIntegration = new LambdaIntegration(getTokensLambda, {
       proxy: true,
       cacheKeyParameters: ["method.request.path.chainId"],
-      cacheNamespace: 'chainId',
+      cacheNamespace: 'getTokens',
       requestParameters: {
         "integration.request.path.chainId": "method.request.path.chainId"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@balancer-labs/sdk": "^0.1.40",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
+        "@sentry/serverless": "^7.29.0",
         "aws-cdk-lib": "^2.32.1",
         "aws-sdk": "^2.1181.0",
         "bignumber.js": "^9.0.1",
@@ -1813,6 +1814,87 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sentry/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-+e9aIp2ljtT4EJq3901z6TfEVEeqZd5cWzbKEuQzPn2UO6If9+Utd7kY2Y31eQYb4QnJgZfiIEz1HonuYY6zqQ==",
+      "dependencies": {
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.29.0.tgz",
+      "integrity": "sha512-s/bN/JS5gPTmwzVms4FtI5YNYtC9aGY4uqdx/llVrIiVv7G6md/oJJzKtO1C4dt6YshjGjSs5KCpEn1NM4+1iA==",
+      "dependencies": {
+        "@sentry/core": "7.29.0",
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/serverless": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-7.29.0.tgz",
+      "integrity": "sha512-cSU51rVJ6wKODIWUVIHaVO3KtDQppq98oWgQywgznjbrxZ2Uhz8rMKCPk/X8YGXorm7zyqz2Vk2SkBUFEN/Lhg==",
+      "dependencies": {
+        "@sentry/node": "7.29.0",
+        "@sentry/tracing": "7.29.0",
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "@types/aws-lambda": "^8.10.62",
+        "@types/express": "^4.17.14",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.29.0.tgz",
+      "integrity": "sha512-MAN/G6XROtRhzo/KDjddb6VJn/Q1TaPLwdyj9vvfkUkBNtlt5k16oXp+u7eHWX0uujER9wnZtj2ivXaPeqq0VA==",
+      "dependencies": {
+        "@sentry/core": "7.29.0",
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-DmoEpoqHPty3VxqubS/5gxarwebHRlcBd/yuno+PS3xy++/i9YPjOWLZhU2jYs1cW68M9R6CcCOiC9f2ckJjdw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.29.0.tgz",
+      "integrity": "sha512-ICcBwTiBGK8NQA8H2BJo0JcMN6yCeKLqNKNMVampRgS6wSfSk1edvcTdhRkW3bSktIGrIPZrKskBHyMwDGF2XQ==",
+      "dependencies": {
+        "@sentry/types": "7.29.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1864,6 +1946,11 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.109",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
+      "integrity": "sha512-/ME92FneNyXQzrAfcnQQlW1XkCZGPDlpi2ao1MJwecN+6SbeonKeggU8eybv1DfKli90FAVT1MlIZVXfwVuCyg=="
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -1909,7 +1996,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1919,28 +2005,25 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+      "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.31",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
-      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "dev": true,
+      "version": "4.17.32",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz",
+      "integrity": "sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1999,14 +2082,12 @@
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
-      "dev": true
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
     },
     "node_modules/@types/prettier": {
       "version": "2.4.4",
@@ -2017,20 +2098,17 @@
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -2329,7 +2407,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -5038,7 +5115,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -6379,6 +6455,11 @@
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -9534,6 +9615,69 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sentry/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-+e9aIp2ljtT4EJq3901z6TfEVEeqZd5cWzbKEuQzPn2UO6If9+Utd7kY2Y31eQYb4QnJgZfiIEz1HonuYY6zqQ==",
+      "requires": {
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.29.0.tgz",
+      "integrity": "sha512-s/bN/JS5gPTmwzVms4FtI5YNYtC9aGY4uqdx/llVrIiVv7G6md/oJJzKtO1C4dt6YshjGjSs5KCpEn1NM4+1iA==",
+      "requires": {
+        "@sentry/core": "7.29.0",
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/serverless": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-7.29.0.tgz",
+      "integrity": "sha512-cSU51rVJ6wKODIWUVIHaVO3KtDQppq98oWgQywgznjbrxZ2Uhz8rMKCPk/X8YGXorm7zyqz2Vk2SkBUFEN/Lhg==",
+      "requires": {
+        "@sentry/node": "7.29.0",
+        "@sentry/tracing": "7.29.0",
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "@types/aws-lambda": "^8.10.62",
+        "@types/express": "^4.17.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.29.0.tgz",
+      "integrity": "sha512-MAN/G6XROtRhzo/KDjddb6VJn/Q1TaPLwdyj9vvfkUkBNtlt5k16oXp+u7eHWX0uujER9wnZtj2ivXaPeqq0VA==",
+      "requires": {
+        "@sentry/core": "7.29.0",
+        "@sentry/types": "7.29.0",
+        "@sentry/utils": "7.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-DmoEpoqHPty3VxqubS/5gxarwebHRlcBd/yuno+PS3xy++/i9YPjOWLZhU2jYs1cW68M9R6CcCOiC9f2ckJjdw=="
+    },
+    "@sentry/utils": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.29.0.tgz",
+      "integrity": "sha512-ICcBwTiBGK8NQA8H2BJo0JcMN6yCeKLqNKNMVampRgS6wSfSk1edvcTdhRkW3bSktIGrIPZrKskBHyMwDGF2XQ==",
+      "requires": {
+        "@sentry/types": "7.29.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -9582,6 +9726,11 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/aws-lambda": {
+      "version": "8.10.109",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
+      "integrity": "sha512-/ME92FneNyXQzrAfcnQQlW1XkCZGPDlpi2ao1MJwecN+6SbeonKeggU8eybv1DfKli90FAVT1MlIZVXfwVuCyg=="
+    },
     "@types/babel__core": {
       "version": "7.1.19",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
@@ -9627,7 +9776,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -9637,28 +9785,25 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+      "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.31",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
-      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "dev": true,
+      "version": "4.17.32",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz",
+      "integrity": "sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -9717,14 +9862,12 @@
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
-      "dev": true
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
     },
     "@types/prettier": {
       "version": "2.4.4",
@@ -9735,20 +9878,17 @@
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -9937,7 +10077,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -11875,7 +12014,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -12886,6 +13024,11 @@
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@balancer-labs/sdk": "^0.1.40",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
+    "@sentry/serverless": "^7.29.0",
     "aws-cdk-lib": "^2.32.1",
     "aws-sdk": "^2.1181.0",
     "bignumber.js": "^9.0.1",

--- a/src/lambdas/check-wallet.ts
+++ b/src/lambdas/check-wallet.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import fetch from 'isomorphic-fetch';
 import { TRMAccountDetails, TRMEntity, TRMRiskIndicator } from '../types';
 import { formatResponse } from './utils';
@@ -6,7 +7,7 @@ const SANCTIONS_ENDPOINT =
   'https://api.trmlabs.com/public/v2/screening/addresses';
 const { SANCTIONS_API_KEY } = process.env;
 
-export const handler = async (event: any = {}): Promise<any> => {
+export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
   const address = event.queryStringParameters.address;
   if (!address) {
     return formatResponse(
@@ -61,4 +62,4 @@ export const handler = async (event: any = {}): Promise<any> => {
     );
     return formatResponse(500, 'Unable to perform sanctions check');
   }
-};
+});

--- a/src/lambdas/decorate-pools.ts
+++ b/src/lambdas/decorate-pools.ts
@@ -2,12 +2,14 @@
  * This lambda runs after prices have been updated, it updates the liquidity of each pool
  * based on the latest token prices + pool token values.
  */
+import { wrapHandler } from '../plugins/sentry';
 import { getPools, getTokens, updatePools } from '../data-providers/dynamodb';
 import { PoolDecorator } from '../pools/pool.decorator';
 
 const { CHAIN_ID } = process.env;
 
-export const handler = async (): Promise<any> => {
+
+export const handler = wrapHandler(async (): Promise<any> => {
   const log = console.log;
 
   const chainId = parseInt(CHAIN_ID || '1');
@@ -33,4 +35,4 @@ export const handler = async (): Promise<any> => {
     log(`Received error: ${err}`);
     return { statusCode: 500, body: JSON.stringify(err) };
   }
-};
+});

--- a/src/lambdas/get-pool.ts
+++ b/src/lambdas/get-pool.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import { getPool } from '../data-providers/dynamodb';
 import { isValidChainId } from '../utils';
 import {
@@ -6,7 +7,7 @@ import {
 } from '../constants/errors';
 import { formatResponse } from './utils';
 
-export const handler = async (event: any = {}): Promise<any> => {
+export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
   const chainId = parseInt(event.pathParameters.chainId);
   if (!chainId) {
     return MISSING_CHAIN_ID_ERROR;
@@ -30,4 +31,4 @@ export const handler = async (event: any = {}): Promise<any> => {
   } catch (dbError) {
     return formatResponse(500, 'Internal DB Error');
   }
-};
+});

--- a/src/lambdas/get-pools.ts
+++ b/src/lambdas/get-pools.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import { getPools } from '../data-providers/dynamodb';
 import { isValidChainId } from '../utils';
 import {
@@ -6,7 +7,7 @@ import {
 } from '../constants/errors';
 import { formatResponse } from './utils';
 
-export const handler = async (event: any = {}): Promise<any> => {
+export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
   const chainId = parseInt(event.pathParameters.chainId);
   if (!chainId) {
     return MISSING_CHAIN_ID_ERROR;
@@ -21,4 +22,4 @@ export const handler = async (event: any = {}): Promise<any> => {
   } catch (dbError) {
     return formatResponse(500, 'Internal DB Error');
   }
-};
+});

--- a/src/lambdas/get-tokens.ts
+++ b/src/lambdas/get-tokens.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import { getTokens } from '../data-providers/dynamodb';
 import { isValidChainId } from '../utils';
 import {
@@ -5,7 +6,7 @@ import {
   MISSING_CHAIN_ID_ERROR,
 } from '../constants/errors';
 
-export const handler = async (event: any = {}): Promise<any> => {
+export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
   const chainId = parseInt(event.pathParameters.chainId);
   if (!chainId) {
     return MISSING_CHAIN_ID_ERROR;
@@ -20,4 +21,4 @@ export const handler = async (event: any = {}): Promise<any> => {
   } catch (dbError) {
     return { statusCode: 500, body: JSON.stringify(dbError) };
   }
-};
+});

--- a/src/lambdas/run-sor.ts
+++ b/src/lambdas/run-sor.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import { getSorSwap } from '../sor';
 import { isValidChainId } from '../utils';
 import {
@@ -5,7 +6,7 @@ import {
   MISSING_CHAIN_ID_ERROR,
 } from '../constants/errors';
 
-export const handler = async (event: any = {}): Promise<any> => {
+export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
   const chainId = parseInt(event.pathParameters.chainId);
   if (!chainId) {
     return MISSING_CHAIN_ID_ERROR;
@@ -29,4 +30,4 @@ export const handler = async (event: any = {}): Promise<any> => {
   } catch (dbError) {
     return { statusCode: 500, body: JSON.stringify(dbError) };
   }
-};
+});

--- a/src/lambdas/tenderly-encode-states.ts
+++ b/src/lambdas/tenderly-encode-states.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import fetch from 'isomorphic-fetch';
 import { formatResponse, isBodyValid } from './utils';
 
@@ -5,7 +6,7 @@ const { TENDERLY_USER, TENDERLY_PROJECT, TENDERLY_ACCESS_KEY } = process.env;
 
 const TENDERLY_ENDPOINT = `https://api.tenderly.co/api/v1/account/${TENDERLY_USER}/project/${TENDERLY_PROJECT}/contracts/encode-states`;
 
-export const handler = async ({ body }: any = {}): Promise<any> => {
+export const handler = wrapHandler(async ({ body }: any = {}): Promise<any> => {
   if (!body) {
     return formatResponse(
       400,
@@ -37,4 +38,4 @@ export const handler = async ({ body }: any = {}): Promise<any> => {
     console.log(`Couldn't encode state overrides: ${e}`);
     return formatResponse(500, "Couldn't encode state overrides");
   }
-};
+});

--- a/src/lambdas/tenderly-simulate.ts
+++ b/src/lambdas/tenderly-simulate.ts
@@ -1,3 +1,4 @@
+import { wrapHandler } from '../plugins/sentry';
 import fetch from 'isomorphic-fetch';
 import { formatResponse, isBodyValid } from './utils';
 
@@ -5,7 +6,7 @@ const { TENDERLY_USER, TENDERLY_PROJECT, TENDERLY_ACCESS_KEY } = process.env;
 
 const TENDERLY_ENDPOINT = `https://api.tenderly.co/api/v1/account/${TENDERLY_USER}/project/${TENDERLY_PROJECT}/simulate`;
 
-export const handler = async ({ body }: any = {}): Promise<any> => {
+export const handler = wrapHandler(async ({ body }: any = {}): Promise<any> => {
   if (!body) {
     return formatResponse(
       400,
@@ -64,4 +65,4 @@ export const handler = async ({ body }: any = {}): Promise<any> => {
     console.log(`Error when trying to simulate: ${e}`);
     return formatResponse(500, 'Unable to perform simulation');
   }
-};
+});

--- a/src/lambdas/update-pools.ts
+++ b/src/lambdas/update-pools.ts
@@ -1,3 +1,5 @@
+import { wrapHandler } from '../plugins/sentry';
+import { captureException } from '@sentry/serverless';
 import { getChangedPools, getTokenAddressesFromPools } from '../utils';
 import { getPools, updatePools, updateTokens } from '../data-providers/dynamodb';
 import {
@@ -9,7 +11,7 @@ import {
 
 const { CHAIN_ID } = process.env;
 
-export const handler = async (): Promise<any> => {
+export const handler = wrapHandler(async (): Promise<any> => {
   const log = console.log;
 
   const chainId = parseInt(CHAIN_ID || '1');
@@ -30,6 +32,7 @@ export const handler = async (): Promise<any> => {
     await updatePools(changedPools);
     
   } catch (dbError) {
+    captureException(dbError);
     log(`Received db error updating pools: ${dbError}`);
     didError = true;
   }
@@ -51,6 +54,7 @@ export const handler = async (): Promise<any> => {
     await updateTokens(tokens);
     log(`Saved ${filteredTokenAddresses.length} Tokens`);
   } catch (dbError) {
+    captureException(dbError);
     log(`Received db error updating tokens: ${dbError}`);
     didError = true; 
   }
@@ -60,5 +64,5 @@ export const handler = async (): Promise<any> => {
   }
 
   return { statusCode: 200, body: '' };
-}
+});
 

--- a/src/lambdas/update-prices.ts
+++ b/src/lambdas/update-prices.ts
@@ -1,7 +1,8 @@
+import { wrapHandler } from '../plugins/sentry';
 import { getTokens } from '../data-providers/dynamodb';
 import { updateTokenPrices } from '../tokens';
 
-export const handler = async (): Promise<any> => {
+export const handler = wrapHandler(async (): Promise<any> => {
   const log = console.log;
 
   try {
@@ -15,4 +16,4 @@ export const handler = async (): Promise<any> => {
     log(`Received error: ${err}`);
     return { statusCode: 500, body: JSON.stringify(err) };
   }
-};
+});

--- a/src/plugins/sentry.ts
+++ b/src/plugins/sentry.ts
@@ -1,0 +1,21 @@
+
+import { AWSLambda } from '@sentry/serverless';
+
+const SENTRY_DSN = process.env.SENTRY_DSN;
+
+export function initSentry() {
+  if (!SENTRY_DSN) return;
+
+  AWSLambda.init({
+    dsn: SENTRY_DSN,
+  
+    tracesSampleRate: 1.0,
+  });
+}
+
+export function wrapHandler(handler) {
+  if (!SENTRY_DSN) return handler;
+
+  initSentry();
+  return AWSLambda.wrapHandler(handler);
+}

--- a/src/pools/pool.decorator.ts
+++ b/src/pools/pool.decorator.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/serverless';
 import { Pool, Token } from '../types';
 import {
   BalancerDataRepositories,
@@ -109,6 +110,7 @@ export class PoolDecorator {
 
       poolService.setIsNew()
     } catch (e) {
+      captureException(e, {extra: { pool }})
       console.log(`Failed to decorate pool ${pool.id} Error is: ${e}. Pool is: ${util.inspect(
         pool,
         false,

--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/serverless';
 import { Pool } from '../../src/types';
 import {
   Pools,
@@ -35,6 +36,7 @@ export class PoolService {
       const calculatedLiquidity = await this.pools.liquidity(this.pool);
       poolLiquidity = calculatedLiquidity;
     } catch (e) {
+      captureException(e, { extra: { pool: this.pool }});
       console.error(
         `Failed to calculate liquidity. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
@@ -47,8 +49,10 @@ export class PoolService {
     }
 
     if (Number(poolLiquidity) == 0 && Number(this.pool.totalLiquidity) > 0) {
+      const liquidityZeroError = `Failed to calculate liquidity. Calculator returned ${poolLiquidity}`;
+      captureException(new Error(liquidityZeroError), { extra: { pool: this.pool }})
       console.error(
-        `Failed to calculate liquidity. Calculator returned ${poolLiquidity}\n
+        `${liquidityZeroError}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
       );
     }
@@ -113,6 +117,7 @@ export class PoolService {
       }
       poolApr = apr;
     } catch (e) {
+      captureException(e, { extra: { pool: this.pool }});
       console.error(
         `Failed to calculate APR. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
@@ -144,6 +149,7 @@ export class PoolService {
       const volume = await this.pools.volume(this.pool);
       volumeSnapshot = volume.toString();
     } catch (e) {
+      captureException(e, { extra: { pool: this.pool }});
       console.error(
         `Failed to calculate Volume. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`
@@ -166,6 +172,7 @@ export class PoolService {
       const fees = await this.pools.fees(this.pool);
       feesSnapshot = fees.toString();
     } catch (e) {
+      captureException(e, { extra: { pool: this.pool }});
       console.error(
         `Failed to calculate Fees. Error is:  ${e}\n
         Pool is:  ${util.inspect(this.pool, false, null)}\n`


### PR DESCRIPTION
- Add Sentry as a plugin that is only initialized when SENTRY_DSN is set so that it only fires in production (or it can be used with another project in dev).
- Wrap Lambda Handlers to capture any Lambdas crashing with Sentry.
- Capture failed to decorate or update pool errors with Sentry.
- fix: Fixed a bug where pools/tokens caches were being intermingled because they had the same cacheNamespace, gave them different namespaces now.

I've created a new Sentry project `api` for this project and have added the DSN to this repositories secrets. You can see some of the captured test errors from my dev account in the Sentry dashboard (I've disabled sending more errors by not including the DSN). 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203070135001261