### PR TITLE
Add rate limiting to Gnosis endpoint

### DIFF
--- a/cdk/waf.ts
+++ b/cdk/waf.ts
@@ -70,6 +70,7 @@ export const rateLimitSettings: CfnWebACLProps = {
     createRule('BlockSpamForPools', '/pools', 200),
     createRule('BlockSpamForTokens', '/tokens', 100),
     createRule('BlockSpamForSor', '/sor', 100),
+    createRule('BlockSpamForGnosis', '/gnosis', 200),
     createRule('BlockSpamForGraphQL', '/graphql', 100),
   ]),
 };


### PR DESCRIPTION
Forgot about this endpoint previously. It's only used by cowswap but we don't want someone to discover and spam it. 