### PR TITLE
Enable detailed metrics, lower Tenderly rate limit

### DIFF
--- a/cdk/waf.ts
+++ b/cdk/waf.ts
@@ -66,7 +66,7 @@ export const rateLimitSettings: CfnWebACLProps = {
   },
   rules: formatRules([
     createRule('BlockSpamForWalletCheck', '/check-wallet', 100),
-    createRule('BlockSpamForTenderly', '/tenderly', 1000),
+    createRule('BlockSpamForTenderly', '/tenderly', 100),
     createRule('BlockSpamForPools', '/pools', 200),
     createRule('BlockSpamForTokens', '/tokens', 100),
     createRule('BlockSpamForSor', '/sor', 100),

--- a/index.ts
+++ b/index.ts
@@ -387,6 +387,7 @@ export class BalancerPoolsAPI extends Stack {
           status: true,
           user: false,
         }),
+        metricsEnabled: true,
         cachingEnabled: false,
         cacheClusterEnabled: true,
         methodOptions: {


### PR DESCRIPTION
- Enable detailed metrics for API Gateway so it shows hits/errors for every route instead of just overall
- Lower the rate limit for Tenderly endpoint to 100/5min (the minimum) as no users should be going over that as it's only used for join/exit simulations. 