### PR TITLE
Don't decorate GyroE and FX pools

### DIFF
--- a/src/pools/pool.decorator.ts
+++ b/src/pools/pool.decorator.ts
@@ -19,7 +19,8 @@ import util from 'util';
 
 const log = debug('balancer:pool-decorator');
 
-const IGNORED_POOL_TYPES = [PoolType.Element, PoolType.Gyro2, PoolType.Gyro3];
+const UNKNOWN_POOL_TYPES = ['GyroE', 'FX']
+const IGNORED_POOL_TYPES = [...UNKNOWN_POOL_TYPES, PoolType.Element, PoolType.Gyro2, PoolType.Gyro3];
 
 export interface PoolDecoratorOptions {
   chainId?: number;


### PR DESCRIPTION
These pools are unknown to the SDK and so throw errors when attempting to decorate them. They may be added to the SDK and decorated in the future but for now we should ignore to cut down on errors.