### PR TITLE
Add sorted maxApr secondary index

### DIFF
--- a/cdk/appsync/pools/requestMapper.vtl
+++ b/cdk/appsync/pools/requestMapper.vtl
@@ -7,8 +7,10 @@
             ":chainId" : $util.dynamodb.toDynamoDBJson($ctx.args.chainId)
         }
     },
-    #if( ${context.arguments.orderBy} == "volume")
+    #if(${context.arguments.orderBy} == "volume")
         "index": "byVolume",
+    #elseif(${context.arguments.orderBy} == "apr")
+        "index": "byApr",
     #else
         "index": "byTotalLiquidity",
     #end

--- a/cdk/appsync/pools/schema.graphql
+++ b/cdk/appsync/pools/schema.graphql
@@ -1,13 +1,18 @@
 ﻿type Pool
   @key(
-    name: "byTotalLiquidity",
-    fields: ["chainId", "totalLiquidity"],
+    name: "byTotalLiquidity"
+    fields: ["chainId", "totalLiquidity"]
     queryField: "poolsByTotalLiquidity"
   )
   @key(
-    name: "byVolume",
-    fields: ["chainId", "volumeSnapshot"],
+    name: "byVolume"
+    fields: ["chainId", "volumeSnapshot"]
     queryField: "poolsByVolume"
+  )
+  @key(
+    name: "byApr"
+    fields: ["chainId", "maxApr"]
+    queryField: "poolsByApr"
   ) {
   chainId: Int!
   id: String!

--- a/index.ts
+++ b/index.ts
@@ -147,6 +147,21 @@ export class BalancerPoolsAPI extends Stack {
       projectionType: ProjectionType.ALL,
     });
 
+    poolsTable.addGlobalSecondaryIndex({
+      indexName: 'byApr',
+      partitionKey: {
+        name: 'chainId',
+        type: AttributeType.NUMBER,
+      },
+      sortKey: {
+        name: 'maxApr',
+        type: AttributeType.NUMBER,
+      },
+      readCapacity: POOLS_IDX_READ_CAPACITY,
+      writeCapacity: POOLS_IDX_WRITE_CAPACITY,
+      projectionType: ProjectionType.ALL,
+    });
+
     const tokensTable = new Table(this, 'tokens', {
       partitionKey: {
         name: 'address',
@@ -534,7 +549,9 @@ export class BalancerPoolsAPI extends Stack {
      */
     const graphqlApi = new GraphqlApi(this, 'Api', {
       name: 'poolsApi',
-      schema: Schema.fromAsset(join(__dirname, 'cdk/appsync/pools/schema.graphql')),
+      schema: Schema.fromAsset(
+        join(__dirname, 'cdk/appsync/pools/schema.graphql')
+      ),
       authorizationConfig: {
         defaultAuthorization: {
           authorizationType: AuthorizationType.API_KEY,

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -12,6 +12,7 @@ export const POOLS_TABLE_SCHEMA: DynamoDB.Types.CreateTableInput = {
     { AttributeName: 'chainId', AttributeType: 'N' },
     { AttributeName: 'totalLiquidity', AttributeType: 'N' },
     { AttributeName: 'volumeSnapshot', AttributeType: 'N' },
+    { AttributeName: 'maxApr', AttributeType: 'N' },
   ],
   ProvisionedThroughput: {
     ReadCapacityUnits: 10,
@@ -37,6 +38,20 @@ export const POOLS_TABLE_SCHEMA: DynamoDB.Types.CreateTableInput = {
       KeySchema: [
         { AttributeName: 'chainId', KeyType: 'HASH' },
         { AttributeName: 'volumeSnapshot', KeyType: 'RANGE' },
+      ],
+      Projection: {
+        ProjectionType: 'ALL',
+      },
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 5,
+        WriteCapacityUnits: 5,
+      },
+    },
+    {
+      IndexName: 'byApr',
+      KeySchema: [
+        { AttributeName: 'chainId', KeyType: 'HASH' },
+        { AttributeName: 'maxApr', KeyType: 'RANGE' },
       ],
       Projection: {
         ProjectionType: 'ALL',

--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -11,7 +11,6 @@ import debug from 'debug';
 import { isEqual } from 'lodash';
 import { isValidApr } from '../utils';
 import { WEEK_IN_MS } from '../constants';
-import BigNumber from 'bignumber.js';
 
 const log = debug('balancer:pools');
 
@@ -137,7 +136,7 @@ export class PoolService {
       this.pool.lastUpdate = Date.now();
     }
 
-    this.pool.maxApr = Number(this.absMaxApr(poolApr, this.pool.boost));
+    this.pool.maxApr = poolApr.max;
     return (this.pool.apr = poolApr);
   }
 
@@ -198,25 +197,5 @@ export class PoolService {
     const isNew = Date.now() - this.pool.createTime * 1000 < WEEK_IN_MS;
 
     return (this.pool.isNew = isNew);
-  }
-
-  /**
-   * @summary Calculates absolute max APR given boost or not.
-   * If given boost returns user's max APR.
-   * If not given boost returns pool absolute max assuming 2.5x boost.
-   * Used primarily for sorting tables by the APR column.
-   */
-  absMaxApr(aprs: AprBreakdown, boost?: string): string {
-    if (boost) {
-      const nonStakingApr = new BigNumber(aprs.swapFees)
-        .plus(aprs.tokenAprs.total)
-        .plus(aprs.rewardAprs.total);
-      const stakingApr = new BigNumber(aprs.stakingApr.min)
-        .times(boost)
-        .toString();
-      return nonStakingApr.plus(stakingApr).toString();
-    }
-
-    return aprs.max.toString();
   }
 }

--- a/src/pools/pool.service.ts
+++ b/src/pools/pool.service.ts
@@ -11,6 +11,7 @@ import debug from 'debug';
 import { isEqual } from 'lodash';
 import { isValidApr } from '../utils';
 import { WEEK_IN_MS } from '../constants';
+import BigNumber from 'bignumber.js';
 
 const log = debug('balancer:pools');
 
@@ -136,6 +137,7 @@ export class PoolService {
       this.pool.lastUpdate = Date.now();
     }
 
+    this.pool.maxApr = Number(this.absMaxApr(poolApr, this.pool.boost));
     return (this.pool.apr = poolApr);
   }
 
@@ -196,5 +198,25 @@ export class PoolService {
     const isNew = Date.now() - this.pool.createTime * 1000 < WEEK_IN_MS;
 
     return (this.pool.isNew = isNew);
+  }
+
+  /**
+   * @summary Calculates absolute max APR given boost or not.
+   * If given boost returns user's max APR.
+   * If not given boost returns pool absolute max assuming 2.5x boost.
+   * Used primarily for sorting tables by the APR column.
+   */
+  absMaxApr(aprs: AprBreakdown, boost?: string): string {
+    if (boost) {
+      const nonStakingApr = new BigNumber(aprs.swapFees)
+        .plus(aprs.tokenAprs.total)
+        .plus(aprs.rewardAprs.total);
+      const stakingApr = new BigNumber(aprs.stakingApr.min)
+        .times(boost)
+        .toString();
+      return nonStakingApr.plus(stakingApr).toString();
+    }
+
+    return aprs.max.toString();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface Pool extends SDKPool {
   managementFee?: string;
   mainIndex?: number;
   wrappedIndex?: number;
+  maxApr?: number;
 }
 
 export interface SorRequest {


### PR DESCRIPTION
This pr adds sorted maxApr secondary index, that will be used, e.g, in sorting pool table on Balancer app main page