### PR TITLE
Add sorRequest details to SOR error capture

### DIFF
--- a/src/lambdas/run-sor.ts
+++ b/src/lambdas/run-sor.ts
@@ -29,7 +29,7 @@ export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
     const swapInfo = await getSorSwap(chainId, sorRequest);
     return { statusCode: 200, body: JSON.stringify(swapInfo) };
   } catch (e) {
-    captureException(e);
+    captureException(e, { extra: { chainId, sorRequest }});
     return { statusCode: 500, body: JSON.stringify(e) };
   }
 });

--- a/src/lambdas/run-sor.ts
+++ b/src/lambdas/run-sor.ts
@@ -30,6 +30,6 @@ export const handler = wrapHandler(async (event: any = {}): Promise<any> => {
     return { statusCode: 200, body: JSON.stringify(swapInfo) };
   } catch (e) {
     captureException(e, { extra: { chainId, sorRequest }});
-    return { statusCode: 500, body: JSON.stringify(e) };
+    return { statusCode: 500, body: JSON.stringify({ error: 'SOR request failed' }) };
   }
 });


### PR DESCRIPTION
Adds additional info about the sor request when sending errors to sentry (e.g. https://sentry.io/organizations/balancer-labs/issues/3897898505/). This is needed to debug why some SOR requests are failing. 

Also made it only return a generic error message so we don't accidentally expose data giving the user the actual exception. 