### PR TITLE
Ignore Transaction Conflicts, lower batch write size

### DIFF
--- a/src/constants/general.ts
+++ b/src/constants/general.ts
@@ -2,7 +2,7 @@ export const COINGECKO_BASEURL = 'https://api.coingecko.com/api/v3';
 export const COINGECKO_MAX_TOKENS_PER_PAGE = 100;
 export const COINGECKO_MAX_TPS = 10;
 
-export const MAX_BATCH_WRITE_SIZE = 20;
+export const MAX_BATCH_WRITE_SIZE = 5;
 export const MAX_DYNAMODB_PRECISION = 38;
 
 export const HOUR_IN_MS = 60 * 60 * 1000;

--- a/src/data-providers/dynamodb.ts
+++ b/src/data-providers/dynamodb.ts
@@ -86,6 +86,12 @@ export async function updatePools(pools: Pool[], options?: UpdatePoolOptions) {
               );
               return;
             }
+            if (e.code === 'TransactionCanceledException' && e.message.includes('TransactionConflict')) {
+              console.error(
+                'Unable to update pools - Conflict with concurrent update'
+              );
+              return;
+            }
             captureException(e, { extra: { poolUpdateRequests }});
             console.error(
               `Unable to update pools ${JSON.stringify(


### PR DESCRIPTION
- Ignore TransactionConflict errors in DynamoDB as they are just caused by the update and decorate lambdas attempting to update the same pool at the same time. As they run so frequently it doesn't really matter if there's a race condition in this way.
- Lower BatchWriteSize to 5 because when this conflict occurs all pools don't get updated, so a smaller batch size ensures less are affected. This shouldn't affect performance.

Fixes: https://sentry.io/organizations/balancer-labs/issues/3865045629/events/e83bb9bdb2ea4172bfc1acc9be49f650/