### PR TITLE
Temporary remove aprs gsi

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -147,20 +147,20 @@ export class BalancerPoolsAPI extends Stack {
       projectionType: ProjectionType.ALL,
     });
 
-    poolsTable.addGlobalSecondaryIndex({
-      indexName: 'byApr',
-      partitionKey: {
-        name: 'chainId',
-        type: AttributeType.NUMBER,
-      },
-      sortKey: {
-        name: 'maxApr',
-        type: AttributeType.NUMBER,
-      },
-      readCapacity: POOLS_IDX_READ_CAPACITY,
-      writeCapacity: POOLS_IDX_WRITE_CAPACITY,
-      projectionType: ProjectionType.ALL,
-    });
+    // poolsTable.addGlobalSecondaryIndex({
+    //   indexName: 'byApr',
+    //   partitionKey: {
+    //     name: 'chainId',
+    //     type: AttributeType.NUMBER,
+    //   },
+    //   sortKey: {
+    //     name: 'maxApr',
+    //     type: AttributeType.NUMBER,
+    //   },
+    //   readCapacity: POOLS_IDX_READ_CAPACITY,
+    //   writeCapacity: POOLS_IDX_WRITE_CAPACITY,
+    //   projectionType: ProjectionType.ALL,
+    // });
 
     const tokensTable = new Table(this, 'tokens', {
       partitionKey: {

--- a/src/constants/dynamodb.ts
+++ b/src/constants/dynamodb.ts
@@ -12,7 +12,7 @@ export const POOLS_TABLE_SCHEMA: DynamoDB.Types.CreateTableInput = {
     { AttributeName: 'chainId', AttributeType: 'N' },
     { AttributeName: 'totalLiquidity', AttributeType: 'N' },
     { AttributeName: 'volumeSnapshot', AttributeType: 'N' },
-    { AttributeName: 'maxApr', AttributeType: 'N' },
+    // { AttributeName: 'maxApr', AttributeType: 'N' },
   ],
   ProvisionedThroughput: {
     ReadCapacityUnits: 10,
@@ -47,20 +47,20 @@ export const POOLS_TABLE_SCHEMA: DynamoDB.Types.CreateTableInput = {
         WriteCapacityUnits: 5,
       },
     },
-    {
-      IndexName: 'byApr',
-      KeySchema: [
-        { AttributeName: 'chainId', KeyType: 'HASH' },
-        { AttributeName: 'maxApr', KeyType: 'RANGE' },
-      ],
-      Projection: {
-        ProjectionType: 'ALL',
-      },
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 5,
-        WriteCapacityUnits: 5,
-      },
-    },
+    // {
+    //   IndexName: 'byApr',
+    //   KeySchema: [
+    //     { AttributeName: 'chainId', KeyType: 'HASH' },
+    //     { AttributeName: 'maxApr', KeyType: 'RANGE' },
+    //   ],
+    //   Projection: {
+    //     ProjectionType: 'ALL',
+    //   },
+    //   ProvisionedThroughput: {
+    //     ReadCapacityUnits: 5,
+    //     WriteCapacityUnits: 5,
+    //   },
+    // },
   ],
 };
 


### PR DESCRIPTION
It's impossible to add/change more than 1 global secondary index per update, so we will add volume gsi and than apr gsi

https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/229