### PR TITLE
Change sdk version to v0.1.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
         "@aws/dynamodb-auto-marshaller": "^0.7.1",
-        "@balancer-labs/sdk": "^v1.0.0-beta.5",
+        "@balancer-labs/sdk": "^v0.1.49",
         "@ethersproject/contracts": "^5.0.5",
         "@ethersproject/providers": "^5.0.5",
         "@sentry/serverless": "^7.29.0",
@@ -658,11 +658,11 @@
       }
     },
     "node_modules/@balancer-labs/sdk": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.5.tgz",
-      "integrity": "sha512-gVA+rwYA+Q5ospNmcTcEfDbpYtQOD5FQ8QYh1FzK/j1lOpMbXIY+mA6noQd0Abv7e4rsWWy5Zl1zbtT3hpetEA==",
+      "version": "0.1.49",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.49.tgz",
+      "integrity": "sha512-q1YYQF5hjMWXhBW8w1K5zuar4ar0amQLBsfE4qp1fBOHuEHwVpZsOlkGm0aAMtoQ5Ab7fFxBZgifewDDamVeWw==",
       "dependencies": {
-        "@balancer-labs/sor": "^4.1.1-beta.0",
+        "@balancer-labs/sor": "^4.1.1-beta.1",
         "@balancer-labs/typechain": "^1.0.0",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",
@@ -11767,11 +11767,11 @@
       }
     },
     "@balancer-labs/sdk": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-1.0.0-beta.5.tgz",
-      "integrity": "sha512-gVA+rwYA+Q5ospNmcTcEfDbpYtQOD5FQ8QYh1FzK/j1lOpMbXIY+mA6noQd0Abv7e4rsWWy5Zl1zbtT3hpetEA==",
+      "version": "0.1.49",
+      "resolved": "https://registry.npmjs.org/@balancer-labs/sdk/-/sdk-0.1.49.tgz",
+      "integrity": "sha512-q1YYQF5hjMWXhBW8w1K5zuar4ar0amQLBsfE4qp1fBOHuEHwVpZsOlkGm0aAMtoQ5Ab7fFxBZgifewDDamVeWw==",
       "requires": {
-        "@balancer-labs/sor": "^4.1.1-beta.0",
+        "@balancer-labs/sor": "^4.1.1-beta.1",
         "@balancer-labs/typechain": "^1.0.0",
         "@ethersproject/abi": "^5.4.0",
         "@ethersproject/abstract-signer": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@aws-cdk/aws-appsync-alpha": "^2.33.0-alpha.0",
     "@aws/dynamodb-auto-marshaller": "^0.7.1",
-    "@balancer-labs/sdk": "^v1.0.0-beta.5",
+    "@balancer-labs/sdk": "^v0.1.49",
     "@ethersproject/contracts": "^5.0.5",
     "@ethersproject/providers": "^5.0.5",
     "@sentry/serverless": "^7.29.0",


### PR DESCRIPTION
Last [update](https://github.com/balancer-labs/balancer-api/pull/169) was made with wrong version. Should be `v0.1.49`