### PR TITLE
Revert "Use beta subgraph for mainnet"

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,7 +140,7 @@ export function getSubgraphURL(chainId: number): string {
       return 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-gnosis-chain-v2';
     case Network.MAINNET:
     default:
-      return 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2-beta';
+      return 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2';
   }
 }
 


### PR DESCRIPTION
Reverts balancer-labs/balancer-api#172

This broke all the volumes / APR's on the site. 