### PR TITLE
Fix number comparison when checking for pool changes

### DIFF
--- a/src/modules/pools/utils.ts
+++ b/src/modules/pools/utils.ts
@@ -71,11 +71,7 @@ export function getNonStaticSchemaFields(schema: Schema): string[] {
 
 export function isSchemaFieldANumber(key: string, schema: Schema): boolean {
   const numberTypes = ['BigDecimal', 'BigInt', 'Int'];
-  if (numberTypes.includes(schema[key]?.type)) {
-    return true;
-  }
-
-  return false;
+  return numberTypes.includes(schema[key]?.type)
 }
 
 export function isSame(newPool: Pool, oldPool?: Pool): boolean {


### PR DESCRIPTION
Some pools were reporting they were changed when values were different as strings but the same as numbers. For example Amp was continually updating for some pools because it was '200.0' from subgraph and '200' in the database. This is how it was reported in the logs:

```
2023-02-21T14:46:48.784Z fbc18015-b462-4430-acd4-995c80c80d74 INFO Updating pool 0x11884da90fb4221b3aa288a7741c51ec4fc43b2f000000000000000000000004 - amp is not equal. New: '200.0' Old: '200'
```

This PR fixes all number comparisons ensuring they are compared as numbers instead of strings. 