### PR TITLE
Increase TPS for /sor and /order endpoints

### DIFF
--- a/cdk/waf.ts
+++ b/cdk/waf.ts
@@ -69,8 +69,8 @@ export const rateLimitSettings: CfnWebACLProps = {
     createRule('BlockSpamForTenderly', '/tenderly', 100),
     createRule('BlockSpamForPools', '/pools', 200),
     createRule('BlockSpamForTokens', '/tokens', 100),
-    createRule('BlockSpamForSor', '/sor', 100),
-    createRule('BlockSpamForGnosis', '/gnosis', 200),
+    createRule('BlockSpamForSor', '/sor', 1000),
+    createRule('BlockSpamForOrder', '/order', 1000),
     createRule('BlockSpamForGraphQL', '/graphql', 100),
   ]),
 };


### PR DESCRIPTION
- Cowswap will be hitting these endpoints more frequently now so increasing their max capacity to 1000 requests per 5 min.
- Adds a rule for /order as well and remove /gnosis as that endpoint has been removed.