### PR TITLE
Increase rate limits for /sor and /order again

### DIFF
--- a/cdk/waf.ts
+++ b/cdk/waf.ts
@@ -69,8 +69,8 @@ export const rateLimitSettings: CfnWebACLProps = {
     createRule('BlockSpamForTenderly', '/tenderly', 100),
     createRule('BlockSpamForPools', '/pools', 200),
     createRule('BlockSpamForTokens', '/tokens', 100),
-    createRule('BlockSpamForSor', '/sor', 1000),
-    createRule('BlockSpamForOrder', '/order', 1000),
+    createRule('BlockSpamForSor', '/sor', 10000),
+    createRule('BlockSpamForOrder', '/order', 10000),
     createRule('BlockSpamForGraphQL', '/graphql', 100),
   ]),
 };


### PR DESCRIPTION
- Cowswap reported they do on average 1000 requests per min, so changing the max rate limit to 2000/min (value is per 5 min)

They have given us some IP addresses we can whitelist and I'll implement that soon and lower the general limit. 